### PR TITLE
Add typesafe-config module.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,3 @@
 runner.dialect = Paradise211
+assumeStandardLibraryStripMargin = true
 project.git = true

--- a/build.sbt
+++ b/build.sbt
@@ -66,19 +66,31 @@ lazy val allSettings = baseSettings ++ publishSettings ++ metaMacroSettings
 lazy val `metaconfig-core` = crossProject
   .settings(
     allSettings,
+    // Position/Input
+    libraryDependencies += "org.scalameta" %% "inputs" % MetaVersion,
     metaMacroSettings
   )
 lazy val `metaconfig-coreJVM` = `metaconfig-core`.jvm
 lazy val `metaconfig-coreJS` = `metaconfig-core`.js
 
+lazy val typesafeConfig = "com.typesafe" % "config" % "1.2.1"
+
+lazy val `metaconfig-typesafe-config` = project
+  .settings(
+    allSettings,
+    description := "Integration for HOCON using typesafehub/config.",
+    libraryDependencies += typesafeConfig
+  )
+  .dependsOn(`metaconfig-coreJVM` % "test->test;compile->compile")
+
 lazy val `metaconfig-hocon` = crossProject
   .settings(
     allSettings,
-    metaMacroSettings
+    description := "Integration for HOCON using custom parser."
   )
   .jvmSettings(
     libraryDependencies ++= Seq(
-      "com.typesafe" % "config" % "1.3.1" % Test
+      typesafeConfig % Test
     )
   )
   .dependsOn(`metaconfig-core` % "test->test;compile->compile")

--- a/metaconfig-core/shared/src/main/scala/metaconfig/Metaconfig.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/Metaconfig.scala
@@ -1,6 +1,8 @@
 package metaconfig
 
+import scala.meta.inputs.Position
 import scala.reflect.ClassTag
+import scala.meta.internal.inputs._
 
 object Metaconfig {
   def getKey(obj: Conf.Obj, keys: Seq[String]): Option[Conf] =
@@ -23,7 +25,12 @@ object Metaconfig {
               s"Error reading field '$path'. " +
                 s"Expected argument of type $simpleName. " +
                 s"Obtained ${e.getMessage}"
-            throw _root_.metaconfig.ConfigError(msg)
+            val formatted = conf.pos match {
+              case Position.None => msg
+              case Position.Range(_, start, _) =>
+                start.formatMessage("error", msg)
+            }
+            throw new IllegalArgumentException(formatted, e)
           case Left(e) => throw e
         }
       case None => default

--- a/metaconfig-core/shared/src/test/scala/metaconfig/DerivationTest.scala
+++ b/metaconfig-core/shared/src/test/scala/metaconfig/DerivationTest.scala
@@ -29,8 +29,7 @@ class DerivationTest extends FunSuite {
   test("invalid field") {
     assert(
       b.reader.read(Conf.Obj("is" -> Conf.Num(2), "var" -> Conf.Num(3))) ==
-        Left(
-          ConfigError("Error reading class 'Bar'. Invalid fields: is, var")))
+        Left(InvalidField("Bar", List("is", "var"))))
   }
 
   test("read OK") {
@@ -54,9 +53,9 @@ class DerivationTest extends FunSuite {
   test("unexpected type") {
     val msg =
       "Error reading field 'i'. Expected argument of type int. Obtained value '\"str\"' of type String."
-    val Left(e @ FailedToReadClass("Bar", _)) =
+    val Left(e: IllegalArgumentException) =
       b.reader.read(Conf.Obj("i" -> Conf.Str("str")))
-    assert(e.getMessage.endsWith(msg))
+    assert(e.getCause != null)
   }
 
   test("write OK") {
@@ -108,10 +107,9 @@ class DerivationTest extends FunSuite {
     val m = Conf.Obj(
       "kase" -> Conf.Str("string")
     )
-    val Left(e @ FailedToReadClass("Ob", _: NotImplementedError)) =
+    val Left(e: IllegalArgumentException) =
       Ob(Kase).reader.read(m)
-    org.scalameta.logger.elem(e)
-    assert(e.getMessage().startsWith("Failed to read 'Ob'"))
+    assert(e.getCause != null)
   }
 
   @DeriveConfDecoder

--- a/metaconfig-hocon/shared/src/main/scala/metaconfig/hocon/Hocon2Class.scala
+++ b/metaconfig-hocon/shared/src/main/scala/metaconfig/hocon/Hocon2Class.scala
@@ -11,7 +11,8 @@ object Hocon2Class {
     try {
       HoconParser.root.parse(str) match {
         case Parsed.Success(value, _) => Right(value)
-        case e @ Parsed.Failure(_, _, _) => Left(metaconfig.ParseError(e.msg))
+        case e @ Parsed.Failure(_, _, _) =>
+          Left(new IllegalArgumentException(e.msg))
       }
     } catch {
       case NonFatal(e) => Left(e)

--- a/metaconfig-typesafe-config/src/main/scala/metaconfig/typesafeconfig/TypesafeConfig2Class.scala
+++ b/metaconfig-typesafe-config/src/main/scala/metaconfig/typesafeconfig/TypesafeConfig2Class.scala
@@ -1,0 +1,75 @@
+package metaconfig
+package typesafeconfig
+
+import com.typesafe.config._
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.meta.inputs._
+import scala.meta.io.AbsolutePath
+
+object TypesafeConfig2Class {
+  def gimmeConfFromString(string: String): Result[Conf] =
+    gimmeSafeConf(() => ConfigFactory.parseString(string))
+  def gimmeConfFromFile(file: java.io.File): Result[Conf] =
+    gimmeSafeConf(() => ConfigFactory.parseFile(file))
+  def gimmeConf(config: Config): Result[Conf] =
+    gimmeSafeConf(() => config)
+
+  private def gimmeSafeConf(f: () => Config): Result[Conf] = {
+    val cache = mutable.Map.empty[Input, Array[Int]]
+    def loop(value: ConfigValue): Conf = {
+      val conf = value match {
+        case x: ConfigObject =>
+          Conf.Obj(
+            x.keySet().asScala.map(key => key -> loop(x.get(key))).toList)
+        case x: ConfigList =>
+          Conf.Lst(x.listIterator().asScala.map(loop).toList)
+        case _ =>
+          value.unwrapped() match {
+            case x: String => Conf.Str(x)
+            case x: java.lang.Integer => Conf.Num(BigDecimal(x))
+            case x: java.lang.Long => Conf.Num(BigDecimal(x))
+            case x: java.lang.Double => Conf.Num(BigDecimal(x))
+            case x: java.lang.Boolean => Conf.Bool(x)
+            case x =>
+              throw new IllegalArgumentException(
+                s"Unexpected config value $value with unwrapped value $x")
+          }
+      }
+      getPosition(value, cache).fold(conf)(conf.withPos)
+    }
+    try {
+      Right(loop(f().resolve().root()))
+    } catch {
+      case scala.util.control.NonFatal(e) =>
+        Left(e)
+    }
+  }
+
+  // Copy-pasted from scala.meta inputs because it's private.
+  // TODO(olafur) expose utility in inputs to get offset from line
+  private def getOffsetByLine(chars: Array[Char]): Array[Int] = {
+    val buf = new mutable.ArrayBuffer[Int]
+    buf += 0
+    var i = 0
+    while (i < chars.length) {
+      if (chars(i) == '\n') buf += (i + 1)
+      i += 1
+    }
+    if (buf.last != chars.length) buf += chars.length // sentinel value used for binary search
+    buf.toArray
+  }
+
+  private def getPosition(
+      value: ConfigValue,
+      cache: mutable.Map[Input, Array[Int]]): Option[Position] =
+    for {
+      origin <- Option(value.origin())
+      url <- Option(origin.url())
+      line <- Option(origin.lineNumber())
+      input = Input.File(new java.io.File(url.toURI))
+      offsetByLine = cache.getOrElseUpdate(input, getOffsetByLine(input.chars))
+      point = Point.Offset(input, offsetByLine(line))
+    } yield Position.Range(input, point, point)
+
+}

--- a/metaconfig-typesafe-config/src/test/scala/metaconfig/typesafeconfig/TypesafeConfig2ClassTest.scala
+++ b/metaconfig-typesafe-config/src/test/scala/metaconfig/typesafeconfig/TypesafeConfig2ClassTest.scala
@@ -1,0 +1,36 @@
+package metaconfig.typesafeconfig
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
+
+import metaconfig.Conf
+import metaconfig.ConfOps
+import org.scalameta.logger
+import org.scalatest.FunSuite
+
+class TypesafeConfig2ClassTest extends FunSuite {
+  test("basic") {
+    val file = File.createTempFile("prefix", ".conf")
+    Files.write(
+      Paths.get(file.toURI),
+      """|a.b = 2
+         |a = [
+         |  1,
+         |  "2"
+         |]
+         |a += true""".stripMargin.getBytes()
+    )
+    val Right(obtained) = TypesafeConfig2Class.gimmeConfFromFile(file)
+    ConfOps.foreach(obtained)(x => logger.elem(x, x.pos))
+    logger.elem(obtained.pos)
+    val expected = Conf.Obj(
+      "a" -> Conf.Lst(
+        Conf.Num(1),
+        Conf.Str("2"),
+        Conf.Bool(true)
+      )
+    )
+    assert(obtained == expected)
+  }
+}


### PR DESCRIPTION
- metaconfig is still 100% used on JVM, it's best to iron out bugs in
  the parser before switching to metaconfig-hocon
- add positions from ConfigOrigin.
- clean up error handling.