### PR TITLE
Add support for null

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,8 @@ lazy val baseSettings = Seq(
 )
 
 lazy val publishSettings = Seq(
-  publishTo := Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2"),
+  publishTo := Some(
+    "releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2"),
   publishArtifact in Test := false,
   licenses := Seq(
     "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
@@ -36,14 +37,13 @@ lazy val publishSettings = Seq(
       "scm:git:git@github.com:olafurpg/metaconfig.git"
     )
   ),
-  pomExtra :=
-    <developers>
-      <developer>
-        <id>olafurpg</id>
-        <name>Ólafur Páll Geirsson</name>
-        <url>https://geirsson.com</url>
-      </developer>
-    </developers>
+  developers +=
+    Developer(
+      "olafurpg",
+      "Ólafur Páll Geirsson",
+      "olafurpg@gmail.com",
+      url("https://geirsson.com")
+    )
 )
 
 lazy val allSettings = baseSettings ++ publishSettings
@@ -96,7 +96,12 @@ inScope(Global)(
     credentials ++= (for {
       username <- sys.env.get("SONATYPE_USERNAME")
       password <- sys.env.get("SONATYPE_PASSWORD")
-    } yield Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password)).toSeq,
+    } yield
+      Credentials(
+        "Sonatype Nexus Repository Manager",
+        "oss.sonatype.org",
+        username,
+        password)).toSeq,
     PgpKeys.pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toCharArray())
   )
 )

--- a/metaconfig-typesafe-config/src/main/scala/metaconfig/typesafeconfig/TypesafeConfig2Class.scala
+++ b/metaconfig-typesafe-config/src/main/scala/metaconfig/typesafeconfig/TypesafeConfig2Class.scala
@@ -37,6 +37,7 @@ object TypesafeConfig2Class {
             case x: java.lang.Long => Conf.Num(BigDecimal(x))
             case x: java.lang.Double => Conf.Num(BigDecimal(x))
             case x: java.lang.Boolean => Conf.Bool(x)
+            case null => Conf.Null()
             case x =>
               throw new IllegalArgumentException(
                 s"Unexpected config value $value with unwrapped value $x")

--- a/metaconfig-typesafe-config/src/test/scala/metaconfig/typesafeconfig/TypesafeConfig2ClassTest.scala
+++ b/metaconfig-typesafe-config/src/test/scala/metaconfig/typesafeconfig/TypesafeConfig2ClassTest.scala
@@ -37,4 +37,21 @@ class TypesafeConfig2ClassTest extends FunSuite {
     f.delete()
     assert(TypesafeConfig2Class.gimmeConfFromFile(f).isNotOk)
   }
+
+  test("null") {
+    val obtained =
+      TypesafeConfig2Class
+        .gimmeConfFromString(
+          """|keywords = [
+             |  null
+             |]""".stripMargin
+        )
+        .get
+    val expected = Conf.Obj(
+      "keywords" -> Conf.Lst(
+        Conf.Null()
+      )
+    )
+    assert(obtained == expected)
+  }
 }


### PR DESCRIPTION
While implementing DisableSyntax.keywords in scalafix I came across the following bug:

```
[info]   java.lang.IllegalArgumentException: Unexpected config value ConfigNull(null) with unwrapped value null
[info]   at metaconfig.typesafeconfig.TypesafeConfig2Class$.loop$1(TypesafeConfig2Class.scala:42)
[info]   at metaconfig.typesafeconfig.TypesafeConfig2Class$.$anonfun$gimmeSafeConf$2(TypesafeConfig2Class.scala:32)
```

In TypesafeConfig indentifier without quotes are lifted two string automatically. For example, it's
possible to write both:

```
keywords = [
  override
]
```

```
keywords = [
  "override"
]
```

However if we write

```
keywords = [
  null
]
```

we get the error above