### PR TITLE
use newer, dbuild-friendly coursier version

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC6")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC13")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "1.3.0")


### PR DESCRIPTION
(having this merged would be convenient for the Scala community build)