### PR TITLE
A whole bag of feature improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val baseSettings = Seq(
   scalaVersion := ScalaVersions.head,
   crossScalaVersions := ScalaVersions,
   libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.13.5" % Test,
-  libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.1" % Test
+  libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.2" % Test
 )
 
 lazy val publishSettings = Seq(
@@ -52,7 +52,11 @@ lazy val `metaconfig-core` = crossProject
   .settings(
     allSettings,
     // Position/Input
-    libraryDependencies += "org.scalameta" %%% "inputs" % MetaVersion
+    libraryDependencies ++= List(
+      "org.scalameta" %%% "inputs" % MetaVersion,
+      "com.lihaoyi" %%% "pprint" % "0.5.3",
+      scalaOrganization.value % "scala-reflect" % scalaVersion.value % Provided
+    )
   )
 lazy val `metaconfig-coreJVM` = `metaconfig-core`.jvm
 lazy val `metaconfig-coreJS` = `metaconfig-core`.js

--- a/metaconfig-core/shared/src/main/scala/metaconfig/Annotations.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/Annotations.scala
@@ -1,0 +1,18 @@
+package metaconfig
+
+import scala.annotation.StaticAnnotation
+
+final case class ExtraName(value: String) extends StaticAnnotation
+final case class DeprecatedName(
+    name: String,
+    message: String,
+    sinceVersion: String)
+    extends StaticAnnotation {
+  override def toString: String =
+    s"Setting '$name' is deprecated since version $sinceVersion. $message"
+}
+final case class ExampleValue(value: String) extends StaticAnnotation
+final case class Description(value: String) extends StaticAnnotation
+final case class SinceVersion(value: String) extends StaticAnnotation
+final case class Deprecated(message: String, since: String)
+    extends StaticAnnotation

--- a/metaconfig-core/shared/src/main/scala/metaconfig/CompositeException.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/CompositeException.scala
@@ -1,0 +1,21 @@
+package metaconfig
+
+final case class CompositeException(head: Throwable, tail: List[Throwable])
+    extends Exception(head.getMessage) {
+  def all: List[Throwable] = head :: tail
+  def add(other: Throwable): CompositeException = other match {
+    case composite @ CompositeException(_, _) =>
+      CompositeException(head, tail ++ composite.all)
+    case _ =>
+      CompositeException(other, head :: tail)
+  }
+  override def getCause: Throwable = head
+}
+
+object CompositeException {
+  def apply(a: Throwable, b: Throwable): CompositeException = (a, b) match {
+    case (c: CompositeException, other) => c.add(other)
+    case (other, c: CompositeException) => c.add(other)
+    case _ => CompositeException(a, b :: Nil)
+  }
+}

--- a/metaconfig-core/shared/src/main/scala/metaconfig/ConfDynamic.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/ConfDynamic.scala
@@ -4,10 +4,10 @@ import scala.language.dynamics
 
 class ConfDynamic(val asConf: Configured[Conf]) extends Dynamic {
   def as[T](implicit ev: ConfDecoder[T]): Configured[T] =
-    asConf.flatMap(_.as[T])
+    asConf.andThen(_.as[T])
   def selectDynamic(name: String): ConfDynamic = {
     val result =
-      asConf.flatMap {
+      asConf.andThen {
         case obj @ Conf.Obj(values) =>
           values
             .collectFirst {
@@ -16,7 +16,9 @@ class ConfDynamic(val asConf: Configured[Conf]) extends Dynamic {
             }
             .getOrElse(ConfError.missingField(obj, name).notOk)
         case els =>
-          ConfError.typeMismatch(s"Conf.Obj (with field $name)", els).notOk
+          ConfError
+            .typeMismatch(s"Conf.Obj (with field $name)", els, name)
+            .notOk
       }
     ConfDynamic(result)
   }

--- a/metaconfig-core/shared/src/main/scala/metaconfig/ConfError.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/ConfError.scala
@@ -1,84 +1,174 @@
 package metaconfig
 
-import scala.meta.internal.inputs._
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.PrintStream
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.nio.file.Path
 import scala.meta.inputs.Position
-import scala.compat.Platform.EOL
+import scala.meta.internal.inputs._
+import metaconfig.ConfError.TypeMismatch
 
-// TODO(olafur) use richer "Message" data type instead of String to support
-// - exceptions with full stack trace
-// - positions
 sealed abstract class ConfError(val msg: String) extends Serializable { self =>
   def extra: List[String] = Nil
-  override def toString: String =
-    if (isEmpty) "No error message"
-    else if (extra.isEmpty) msg
+  final def all: List[String] = msg :: extra
+  final override def toString: String =
+    if (isEmpty) "No error message provided"
+    else if (extra.isEmpty) stackTrace
     else {
-      val all = msg :: extra
-      val orderedList = all.mkString("\n\n")
-      orderedList
+      val sb = new StringWriter()
+      val out = new PrintWriter(sb)
+      if (extra.nonEmpty) out.println(s"${extra.length + 1} errors")
+      all.zipWithIndex.foreach {
+        case (err, i) => out.append(s"[E$i] ").println(err)
+      }
+      sb.toString
     }
-  def notOk = Configured.NotOk(this)
-  override def hashCode(): Int = (msg.hashCode << 1) | (if (hasPos) 1 else 0)
+  final def stackTrace: String = cause match {
+    case Some(ex) =>
+      val baos = new ByteArrayOutputStream()
+      ex.printStackTrace(new PrintStream(baos))
+      baos.toString
+    case None => msg
+  }
 
-  override def equals(obj: scala.Any): Boolean = obj match {
+  final def notOk: Configured[Nothing] = Configured.NotOk(this)
+  final def left[A]: Either[ConfError, A] = Left(this)
+
+  final override def hashCode(): Int =
+    (msg.hashCode << 1) | (if (hasPos) 1 else 0)
+  final override def equals(obj: scala.Any): Boolean = obj match {
     case err: ConfError => hasPos == err.hasPos && msg == err.msg
     case _ => false
   }
 
-  def isEmpty = msg.isEmpty && extra.isEmpty
+  def isEmpty: Boolean = msg.isEmpty && extra.isEmpty
 
-  def hasPos: Boolean = false
   def combine(other: ConfError): ConfError =
     if (isEmpty) other
     else if (other.isEmpty) this
     else {
-      new ConfError(msg) {
+      new ConfError(stackTrace) {
         override def extra: List[String] =
-          other.msg :: (other.extra ++ self.extra)
+          other.stackTrace :: (other.extra ++ self.extra)
+        override def cause: Option[Throwable] =
+          if (self.cause.isEmpty) other.cause
+          else if (other.cause.isEmpty) self.cause
+          else Some(CompositeException(self.cause.get, other.cause.get))
+        override def isParseError: Boolean =
+          this.isParseError || other.isParseError
+        override def isMissingField: Boolean =
+          this.isMissingField || other.isMissingField
+        override def typeMismatch: Option[TypeMismatch] =
+          self.typeMismatch.orElse(other.typeMismatch)
       }
     }
 
-  def atPos(position: Position): ConfError =
+  def hasPos: Boolean = false
+  final def atPos(position: Position): ConfError =
     if (hasPos) this // avoid duplicate position
+    else if (position == Position.None) this
     else {
       new ConfError(position.formatMessage("error", msg)) {
         override def hasPos: Boolean = true
       }
     }
+
+  // TODO(olafur) this is nothing but pure abusal of overriding and custom classes
+  // Maybe it's better to model everything as a `List[ErrorADT]`
+  def cause: Option[Throwable] = None
+  final def isException: Boolean = cause.nonEmpty
+  def isMissingField: Boolean = false
+  def isParseError: Boolean = false
+  def typeMismatch: Option[TypeMismatch] = None
+  def isTypeMismatch: Boolean = false
+  def isDeprecation: Boolean = false
+
+  def copy(newMsg: String): ConfError = new ConfError(newMsg) {
+    override def hasPos: Boolean = self.hasPos
+    override def cause: Option[Throwable] = self.cause
+    override def isTypeMismatch: Boolean = self.isTypeMismatch
+    override def isParseError: Boolean = self.isParseError
+    override def isMissingField: Boolean = self.isMissingField
+  }
 }
 
 object ConfError {
-  lazy val empty = new ConfError("") {}
+  case class TypeMismatch(obtained: String, expected: String, path: String)
+
+  lazy val empty: ConfError = new ConfError("") {}
+
+  def deprecated(
+      name: String,
+      message: String,
+      sinceVersion: String): ConfError =
+    deprecated(DeprecatedName(name, message, sinceVersion))
+  def deprecated(deprecation: DeprecatedName): ConfError =
+    new ConfError(deprecation.toString) {
+      override def isDeprecation: Boolean = true
+    }
 
   def msg(message: String): ConfError =
     new ConfError(message) {}
-  def exception(e: Throwable, stackSize: Int = 10): ConfError =
-    msg(s"""$e
-           |${e.getStackTrace.take(stackSize).mkString("\n")}""".stripMargin)
+  def exception(e: Throwable, stackSize: Int = 10): ConfError = {
+    e.setStackTrace(e.getStackTrace.take(stackSize))
+    new ConfError(e.getMessage) {
+      override def cause: Option[Throwable] = Some(e)
+    }
+  }
+  def fileDoesNotExist(path: Path): ConfError =
+    fileDoesNotExist(path.toAbsolutePath.toString)
+  def fileDoesNotExist(file: File): ConfError =
+    fileDoesNotExist(file.getAbsolutePath)
   def fileDoesNotExist(path: String): ConfError =
     msg(s"File $path does not exist.")
   def parseError(position: Position, message: String): ConfError =
-    msg(position.formatMessage("parseerror", message))
+    new ConfError(position.formatMessage("error", message)) {
+      override def isParseError: Boolean = true
+    }
   def typeMismatch(expected: String, obtained: Conf): ConfError =
-    msg(
-      s"""Type mismatch;
-         |  found    : ${obtained.kind} (value: $obtained)
+    typeMismatch(expected, obtained, "")
+  def typeMismatch(expected: String, obtained: Conf, path: String): ConfError = {
+    typeMismatch(expected, s"${obtained.kind} (value: $obtained)", path)
+  }
+  def typeMismatch(
+      expected: String,
+      obtained: String,
+      path: String): ConfError = {
+    val pathSuffix = if (path.isEmpty) "" else s" at '$path'"
+    new ConfError(
+      s"""Type mismatch$pathSuffix;
+         |  found    : $obtained
          |  expected : $expected""".stripMargin
-    )
+    ) {
+      override def isTypeMismatch: Boolean = true
+    }
+  }
+
   def missingField(obj: Conf.Obj, field: String): ConfError = {
-    val closestField =
-      if (obj.values.isEmpty) ""
-      else obj.keys.sorted.minBy(levenshtein(field))
-    msg(
-      s"Object $obj has no field '$field'. " +
-        s"Did you mean '$closestField' instead?")
+    val hint =
+      if (obj.values.lengthCompare(1) <= 0) ""
+      else {
+        val closestField =
+          if (obj.values.isEmpty) ""
+          else obj.keys.sorted.minBy(levenshtein(field))
+        s" Did you mean '$closestField' instead?"
+      }
+    new ConfError(s"$obj has no field '$field'." + hint) {
+      override def isMissingField: Boolean = true
+    }
   }
 
   // TOOD(olafur) levenshtein
   def invalidFields(
       invalid: Iterable[String],
-      valid: Iterable[String]): ConfError =
-    new ConfError(s"Invalid fields: ${invalid.mkString(", ")}") {}
+      valid: Iterable[String]): ConfError = {
+    val plural = if (invalid.size > 1) "s" else ""
+    new ConfError(
+      s"Invalid field$plural: ${invalid.mkString(", ")}. " +
+        s"Expected one of ${valid.mkString(", ")}") {}
+  }
 
   def fromResults(results: Seq[Configured[_]]): Option[ConfError] =
     apply(results.collect { case Configured.NotOk(x) => x })

--- a/metaconfig-core/shared/src/main/scala/metaconfig/DefaultValue.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/DefaultValue.scala
@@ -1,0 +1,23 @@
+package metaconfig
+
+case class DefaultValue[+T](value: T, show: () => String)
+
+object DefaultValue {
+  def apply[T](e: T)(implicit ev: DefaultValueShow[T]): DefaultValue[T] = {
+    DefaultValue(e, () => ev.show(e))
+  }
+}
+trait DefaultValueShow[T] {
+  def show(e: T): String
+}
+
+trait LowPriorityDefaultValueShow {
+  lazy val DefaultValueShowAny: DefaultValueShow[Any] =
+    new DefaultValueShow[Any] {
+      override def show(e: Any): String = e.toString
+    }
+  implicit def DefaultValueShowToString[T]: DefaultValueShow[T] =
+    DefaultValueShowAny.asInstanceOf[DefaultValueShow[T]]
+}
+
+object DefaultValueShow extends LowPriorityDefaultValueShow

--- a/metaconfig-core/shared/src/main/scala/metaconfig/Field.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/Field.scala
@@ -1,0 +1,30 @@
+package metaconfig
+
+import scala.annotation.StaticAnnotation
+import scala.reflect.ClassTag
+
+/**
+  * Metadata about one field of a class.
+  *
+  * @param name the parameter name of this field.
+  * @param defaultValue the default value of this parameter, if any
+  * @param classTag the classtag of the the type of this field
+  * @param annotations static annotations attached to this field.
+  */
+final case class Field(
+    name: String,
+    defaultValue: Option[DefaultValue[_]],
+    classTag: ClassTag[_],
+    annotations: List[StaticAnnotation]
+)
+
+/**
+  * Aggregated metadata about a given type.
+  *
+  * @param fields the fields of this type
+  * @tparam T not used for anything but to drive implicit resolution.
+  */
+case class Surface[T](fields: List[Field])
+object Surface {
+  def apply[T](implicit ev: Surface[T]): Surface[T] = ev
+}

--- a/metaconfig-core/shared/src/main/scala/metaconfig/HasFields.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/HasFields.scala
@@ -1,0 +1,6 @@
+package metaconfig
+
+@deprecated("This is never used", "0.6.0")
+trait HasFields {
+  def fields: Map[String, Any]
+}

--- a/metaconfig-core/shared/src/main/scala/metaconfig/Metaconfig.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/Metaconfig.scala
@@ -39,7 +39,9 @@ object Metaconfig {
         conf match {
           case obj @ Conf.Obj(_) => ConfError.missingField(obj, path).notOk
           case _ =>
-            ConfError.typeMismatch(s"Conf.Obj with field $path", conf).notOk
+            ConfError
+              .typeMismatch(s"Conf.Obj with field $path", conf, path)
+              .notOk
         }
     }
   }

--- a/metaconfig-core/shared/src/main/scala/metaconfig/Setting.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/Setting.scala
@@ -1,0 +1,43 @@
+package metaconfig
+
+import scala.annotation.StaticAnnotation
+import scala.reflect.ClassTag
+
+final class Setting(val field: Field) {
+  def name: String = field.name
+  def annotations: List[StaticAnnotation] = field.annotations
+
+  def description: Option[String] = field.annotations.collectFirst {
+    case Description(value) => value
+  }
+  def extraNames: List[String] = field.annotations.collect {
+    case ExtraName(value) => value
+  }
+  def deprecatedNames: List[DeprecatedName] = field.annotations.collect {
+    case d: DeprecatedName => d
+  }
+  def exampleValues: List[String] = field.annotations.collect {
+    case ExampleValue(value) => value
+  }
+  def sinceVersion: Option[String] = field.annotations.collectFirst {
+    case SinceVersion(value) => value
+  }
+  def deprecated: Option[Deprecated] = field.annotations.collectFirst {
+    case value: Deprecated => value
+  }
+  def alternativeNames: List[String] =
+    extraNames ::: deprecatedNames.map(_.name)
+  def allNames: List[String] = name :: alternativeNames
+  def deprecation(name: String): Option[DeprecatedName] =
+    deprecatedNames.find(_.name == name)
+}
+
+object Setting {
+  def apply[T: ClassTag](name: String): Setting =
+    new Setting(Field(name, None, implicitly[ClassTag[T]], Nil))
+  def apply[T: ClassTag: DefaultValueShow](
+      name: String,
+      defaultValue: T): Setting = new Setting(
+    Field(name, Some(DefaultValue(defaultValue)), implicitly[ClassTag[T]], Nil)
+  )
+}

--- a/metaconfig-core/shared/src/main/scala/metaconfig/Settings.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/Settings.scala
@@ -1,0 +1,26 @@
+package metaconfig
+
+final class Settings[T](val settings: List[Setting]) {
+  object Deprecated {
+    def unapply(key: String): Option[DeprecatedName] =
+      (for {
+        setting <- settings
+        deprecation <- setting.deprecation(key).toList
+      } yield deprecation).headOption
+  }
+  def allNames: List[String] =
+    for {
+      setting <- settings
+      name <- setting.allNames
+    } yield name
+  def getOption(name: String): Option[Setting] =
+    settings.find(_.allNames.contains(name))
+  def get(name: String): Setting = getOption(name).get
+}
+
+object Settings {
+  implicit def FieldsToSettings[T](implicit ev: Surface[T]): Settings[T] =
+    apply(ev)
+  def apply[T](implicit ev: Surface[T]): Settings[T] =
+    new Settings[T](ev.fields.map(new Setting(_)))
+}

--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/CanBuildFromDecoder.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/CanBuildFromDecoder.scala
@@ -1,0 +1,59 @@
+package metaconfig.internal
+
+import scala.language.higherKinds
+
+import scala.collection.generic.CanBuildFrom
+import scala.reflect.ClassTag
+import metaconfig.Conf
+import metaconfig.ConfDecoder
+import metaconfig.ConfError
+import metaconfig.Configured
+import metaconfig.Configured.NotOk
+import metaconfig.Configured.Ok
+
+object CanBuildFromDecoder {
+  def map[A](
+      implicit ev: ConfDecoder[A],
+      classTag: ClassTag[A]): ConfDecoder[Map[String, A]] =
+    ConfDecoder.instanceExpect[Map[String, A]](
+      s"Map[String, ${classTag.runtimeClass.getName}]") {
+      case Conf.Obj(values) =>
+        val results = values.map {
+          case (key, value) => ev.read(value).map(key -> _)
+        }
+        ConfError.fromResults(results) match {
+          case Some(err) => NotOk(err)
+          case None =>
+            Ok(results.collect { case Ok(x) => x }.toMap)
+        }
+    }
+  def list[C[_], A](
+      implicit ev: ConfDecoder[A],
+      cbf: CanBuildFrom[Nothing, A, C[A]],
+      classTag: ClassTag[A]): ConfDecoder[C[A]] =
+    new ConfDecoder[C[A]] {
+      override def read(conf: Conf): Configured[C[A]] = conf match {
+        case Conf.Lst(values) =>
+          val successB = cbf()
+          val errorB = List.newBuilder[ConfError]
+          successB.sizeHint(values.length)
+          values.foreach { value =>
+            ev.read(value) match {
+              case NotOk(e) => errorB += e
+              case Ok(e) => successB += e
+            }
+          }
+          ConfError(errorB.result()) match {
+            case Some(x) => NotOk(x)
+            case None => Ok(successB.result())
+          }
+        case _ =>
+          val error = ConfError.typeMismatch(
+            s"List[${classTag.runtimeClass.getName}]",
+            conf
+          )
+          NotOk(error)
+      }
+    }
+
+}

--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/Macros.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/Macros.scala
@@ -1,0 +1,132 @@
+package metaconfig.internal
+
+import scala.language.experimental.macros
+
+import scala.annotation.StaticAnnotation
+import scala.reflect.ClassTag
+import scala.reflect.macros.blackbox
+import metaconfig._
+import org.scalameta.logger
+
+object Macros {
+  def deriveSurface[T]: Surface[T] = macro Macros.deriveSurfaceImpl[T]
+  def deriveConfDecoder[T](default: T): ConfDecoder[T] =
+    macro Macros.deriveConfDecoderImpl[T]
+}
+
+class Macros(val c: blackbox.Context) {
+  import c.universe._
+  def assumeClass[T: c.WeakTypeTag]: Type = {
+    val T = weakTypeOf[T]
+    if (!T.typeSymbol.isClass || !T.typeSymbol.asClass.isCaseClass)
+      c.abort(c.enclosingPosition, s"$T must be a case class")
+    T
+  }
+  def deriveConfDecoderImpl[T: c.WeakTypeTag](default: Tree): Tree = {
+    val T = assumeClass[T]
+    val Tclass = T.typeSymbol.asClass
+    val settings = c.inferImplicitValue(weakTypeOf[Settings[T]])
+    if (settings == null || settings.isEmpty) {
+      c.abort(
+        c.enclosingPosition,
+        s"Missing implicit for ${weakTypeOf[Settings[T]]}]. " +
+          s"Hint, add `implicit val surface: ${weakTypeOf[Surface[T]]}` " +
+          s"to the companion ${T.companion.typeSymbol}"
+      )
+    }
+    val paramss = Tclass.primaryConstructor.asMethod.paramLists
+    if (paramss.size > 1) {
+      c.abort(
+        c.enclosingPosition,
+        s"Curried parameter lists are not supported yet."
+      )
+    }
+
+    val (head :: params) :: Nil = paramss
+    def next(param: Symbol): Tree = {
+      val P = param.info.resultType
+      val name = param.name.decodedName.toString
+      val getter = T.member(param.name)
+      val fallback = q"tmp.$getter"
+      val next = q"conf.getSettingOrElse[$P](settings.get($name), $fallback)"
+      next
+    }
+    val product = params.foldLeft(next(head)) {
+      case (accum, param) => q"$accum.product(${next(param)})"
+    }
+    val tupleExtract = 1.to(params.length).foldLeft(q"t": Tree) {
+      case (accum, _) => q"$accum._1"
+    }
+    var curr = tupleExtract
+    val args = 0.to(params.length).map { _ =>
+      val old = curr
+      curr = curr match {
+        case q"$qual._1" =>
+          q"$qual._2"
+        case q"$qual._1._2" =>
+          q"$qual._2"
+        case q"$qual._2" =>
+          q"$qual"
+        case q"t" => q"t"
+      }
+      old
+    }
+    val ctor = q"new $T(..$args)"
+
+    val result = q"""
+       new ${weakTypeOf[ConfDecoder[T]]} {
+         def read(conf: _root_.metaconfig.Conf): ${weakTypeOf[Configured[T]]} = {
+             val settings = $settings
+             val tmp = $default
+             $product.map { t =>
+               $ctor
+             }
+         }
+       }
+     """
+    result
+  }
+
+  def deriveSurfaceImpl[T: c.WeakTypeTag]: Tree = {
+    val T = weakTypeOf[T]
+    if (!T.typeSymbol.isClass || !T.typeSymbol.asClass.isCaseClass)
+      c.abort(c.enclosingPosition, s"$T must be a case class")
+    val Tclass = T.typeSymbol.asClass
+    val none = typeOf[None.type].termSymbol
+    val some = typeOf[Some[_]].typeSymbol
+    val ctor = Tclass.primaryConstructor.asMethod
+    val fields = for {
+      (params, i) <- ctor.paramLists.zipWithIndex
+      (param, j) <- params.zipWithIndex
+    } yield {
+      val default = if (i == 0 && param.asTerm.isParamWithDefault) {
+        val nme = TermName(termNames.CONSTRUCTOR + "$default$" + (j + 1)).encodedName.toTermName
+        val getter = T.companion.member(nme)
+        val defaultValue = q"_root_.metaconfig.DefaultValue($getter)"
+        q"new $some($defaultValue)"
+      } else q"$none"
+      val annots = param.annotations.collect {
+        case annot if annot.tree.tpe <:< typeOf[StaticAnnotation] =>
+          annot.tree
+      }
+      val paramTpe = internal.typeRef(
+        NoPrefix,
+        typeOf[ClassTag[_]].typeSymbol,
+        param.info :: Nil
+      )
+
+      val classtag = c.inferImplicitValue(paramTpe)
+      val field = q"""new _root_.metaconfig.Field(
+           ${param.name.decodedName.toString},
+           $default,
+           $classtag,
+           _root_.scala.List.apply(..$annots)
+         )"""
+      field
+    }
+    val args = q"_root_.scala.List.apply(..$fields)"
+    val result = q"new ${weakTypeOf[Surface[T]]}($args)"
+    c.untypecheck(result)
+  }
+
+}

--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/NoTyposDecoder.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/NoTyposDecoder.scala
@@ -1,0 +1,27 @@
+package metaconfig.internal
+
+import metaconfig.Conf
+import metaconfig.ConfDecoder
+import metaconfig.ConfError
+import metaconfig.Configured
+import metaconfig.Settings
+
+object NoTyposDecoder {
+  def apply[A](underlying: ConfDecoder[A])(
+      implicit ev: Settings[A]): ConfDecoder[A] =
+    new ConfDecoder[A] {
+      override def read(conf: Conf): Configured[A] = conf match {
+        case Conf.Obj(values) =>
+          val names = ev.allNames
+          val typos = values.collect {
+            case (key, _) if !names.contains(key) =>
+              key
+          }
+          if (typos.isEmpty) underlying.read(conf)
+          else ConfError.invalidFields(typos, ev.settings.map(_.name)).notOk
+        case els =>
+          ConfError.typeMismatch("Object", els).notOk
+      }
+    }
+
+}

--- a/metaconfig-core/shared/src/test/scala/metaconfig/ConfErrorSuite.scala
+++ b/metaconfig-core/shared/src/test/scala/metaconfig/ConfErrorSuite.scala
@@ -1,0 +1,84 @@
+package metaconfig
+
+import org.scalatest.FunSuite
+import ConfError._
+import metaconfig.Conf._
+import org.langmeta.inputs.Input
+import org.langmeta.inputs.Position
+
+class ConfErrorSuite extends FunSuite {
+
+  def check(name: String, error: => ConfError, expected: => String): Unit = {
+    test(name) {
+      val obtained = error.toString.trim
+      assert(obtained == expected)
+    }
+  }
+
+  check(
+    "typeMismatch",
+    typeMismatch("A", Str("B")),
+    """Type mismatch;
+      |  found    : String (value: "B")
+      |  expected : A""".stripMargin
+  )
+
+  check(
+    "typeMismatch2",
+    typeMismatch("A", "B", "C"),
+    """Type mismatch at 'C';
+      |  found    : B
+      |  expected : A""".stripMargin
+  )
+
+  check(
+    "invalidFields",
+    invalidFields(List("A"), List("B", "C")),
+    "Invalid field: A. Expected one of B, C"
+  )
+
+  check(
+    "missingField",
+    missingField(Obj("foobar" -> Str("2"), "qux" -> Num(2)), "fuzbar"),
+    """{"foobar": "2", "qux": 2} has no field 'fuzbar'. Did you mean 'foobar' instead?"""
+  )
+
+  check(
+    "combine",
+    msg("message 1").combine(msg("message 2")),
+    """|2 errors
+       |[E0] message 1
+       |[E1] message 2""".stripMargin
+  )
+
+  check(
+    "deprecated",
+    deprecated("name", "Use field instead", "v1.0"),
+    """Setting 'name' is deprecated since version v1.0. Use field instead""".stripMargin
+  )
+
+  check(
+    "fileDoesNotExist",
+    fileDoesNotExist("/path/to.txt"),
+    """File /path/to.txt does not exist.""".stripMargin
+  )
+
+  check(
+    "parseError", {
+      val input = Input.VirtualFile(
+        "foo.scala",
+        """
+          |object A {
+          |  var x
+          |}
+        """.stripMargin
+      )
+      val i = input.value.indexOf('v')
+      val pos = Position.Range(input, i, i + 2)
+      parseError(pos, "No var")
+    },
+    """|foo.scala:3: error: No var
+       |var x
+       |  ^""".stripMargin
+  )
+}

--- a/metaconfig-core/shared/src/test/scala/metaconfig/DeriveConfDecoderSuite.scala
+++ b/metaconfig-core/shared/src/test/scala/metaconfig/DeriveConfDecoderSuite.scala
@@ -1,0 +1,178 @@
+package metaconfig
+
+import java.io.File
+import metaconfig.Conf._
+import metaconfig.internal.Macros
+import org.scalatest.FunSuite
+
+case class AllTheAnnotations(
+    @Description("descriptioon")
+    @ExampleValue("value")
+    @ExampleValue("value2")
+    @ExtraName("extraName")
+    @ExtraName("extraName2")
+    @DeprecatedName("deprecatedName", "Use x instead", "2.0")
+    @DeprecatedName("deprecatedName2", "Use y instead", "3.0")
+    @SinceVersion("2.1")
+    @Description("Description")
+    @Deprecated("Use newFeature instead", "2.1")
+    number: Int = 2,
+    string: String = "string",
+    lst: List[String] = Nil
+)
+
+object AllTheAnnotations {
+  implicit lazy val fields: Surface[AllTheAnnotations] =
+    Macros.deriveSurface[AllTheAnnotations]
+  lazy val settings = Settings[AllTheAnnotations]
+  implicit lazy val decoder: ConfDecoder[AllTheAnnotations] =
+    Macros.deriveConfDecoder[AllTheAnnotations](AllTheAnnotations()).noTypos
+}
+
+class DeriveSurfaceSuite extends FunSuite {
+
+  case class WithFile(file: File)
+  test("Surface[T]") {
+    assertCompiles("Macros.deriveSurface[WithFile]")
+  }
+
+  test("Settings[T]") {
+    val List(s1, s2, _) = Settings[AllTheAnnotations].settings
+    assert(s1.name == "number")
+    assert(
+      s1.extraNames == List(
+        "extraName",
+        "extraName2"
+      )
+    )
+    assert(
+      s1.deprecatedNames ==
+        List(
+          DeprecatedName("deprecatedName", "Use x instead", "2.0"),
+          DeprecatedName("deprecatedName2", "Use y instead", "3.0"))
+    )
+    assert(
+      s1.exampleValues ==
+        List("value", "value2")
+    )
+    assert(s1.description.contains("descriptioon"))
+    assert(s1.sinceVersion.contains("2.1"))
+    assert(
+      s1.deprecated.contains(Deprecated("Use newFeature instead", "2.1"))
+    )
+
+    assert(s2.name == "string")
+    assert(s2.annotations.isEmpty)
+  }
+
+}
+class DeriveConfDecoderSuite extends FunSuite {
+
+  def checkError(name: String, obj: Conf, expected: String): Unit = {
+    test(name) {
+      ConfDecoder.decode[AllTheAnnotations](obj) match {
+        case Configured.NotOk(err) =>
+          assert(expected == err.toString)
+        case Configured.Ok(obtained) =>
+          fail(s"Expected error, obtained=$obtained")
+      }
+    }
+  }
+  def checkOk(name: String, obj: Conf, expected: AllTheAnnotations): Unit = {
+    test(name) {
+      ConfDecoder.decode[AllTheAnnotations](obj) match {
+        case Configured.NotOk(err) =>
+          fail(err.toString)
+        case Configured.Ok(obtained) =>
+          assert(obtained == expected)
+      }
+    }
+  }
+
+  private val number = "number" -> Num(42)
+  private val string = "string" -> Str("42")
+
+  checkError(
+    "typo",
+    Obj(number, "sttring" -> Str("42")),
+    "Invalid field: sttring. Expected one of number, string, lst"
+  )
+
+  checkError(
+    "typo2",
+    Obj(string, "nummbber" -> Str("42")),
+    "Invalid field: nummbber. Expected one of number, string, lst"
+  )
+
+  checkOk(
+    "basic",
+    Obj(
+      "number" -> Num(42),
+      "string" -> Str("42"),
+      "lst" -> Lst(Str("43") :: Nil)
+    ),
+    AllTheAnnotations(42, "42", List("43"))
+  )
+
+  checkOk(
+    "extraName",
+    Obj("extraName" -> Num(33)),
+    AllTheAnnotations(33, "string", List())
+  )
+
+  checkOk(
+    "extraName2",
+    Obj("extraName2" -> Num(33)),
+    AllTheAnnotations(33, "string", List())
+  )
+
+  checkOk(
+    "deprecatedName",
+    Obj("deprecatedName" -> Num(33)),
+    AllTheAnnotations(33, "string", List())
+  )
+
+  checkOk(
+    "deprecatedName2",
+    Obj("deprecatedName2" -> Num(33)),
+    AllTheAnnotations(33, "string", List())
+  )
+
+  case class OneParam(param: Int)
+  object OneParam {
+    implicit val surface: Surface[OneParam] = Macros.deriveSurface[OneParam]
+  }
+  test("one param") {
+    val decoder = Macros.deriveConfDecoder[OneParam](OneParam(42))
+    val obtained = decoder.read(Obj("param" -> Num(2))).get
+    val expected = OneParam(2)
+    assert(obtained == expected)
+  }
+
+  case class Curry(a: Int)(b: String)
+  object Curry {
+    implicit val surface: Surface[Curry] = Macros.deriveSurface[Curry]
+  }
+  case class NoCurry(a: Int)
+  object NoCurry {
+    implicit val surface: Surface[NoCurry] = Macros.deriveSurface[NoCurry]
+  }
+
+  test("compile error") {
+    assertCompiles("""Macros.deriveConfDecoder[NoCurry](NoCurry(1))""")
+    assertDoesNotCompile("""Macros.deriveConfDecoder[Curry](Curry(1)("")""")
+  }
+
+  case class MissingSurface(b: Int)
+  test("missing surface ") {
+    assertDoesNotCompile(
+      """Macros.deriveConfDecoder[MissingSurface](MissingSurface(1))"""
+    )
+    assertCompiles(
+      """{
+        |  implicit val surface = Macros.deriveSurface[MissingSurface]
+        |  Macros.deriveConfDecoder[MissingSurface](MissingSurface(1))
+        |}""".stripMargin
+    )
+  }
+}

--- a/metaconfig-hocon/shared/src/main/scala/metaconfig/hocon/Hocon2Class.scala
+++ b/metaconfig-hocon/shared/src/main/scala/metaconfig/hocon/Hocon2Class.scala
@@ -22,10 +22,9 @@ object Hocon2Class {
       configStr: Input,
       reader: metaconfig.ConfDecoder[T],
       path: Option[String] = None): metaconfig.Configured[T] = {
-    for {
-      config <- gimmeConfig(configStr)
-      clz <- reader.read(config.normalize)
-    } yield clz
+    gimmeConfig(configStr).andThen { config =>
+      reader.read(config.normalize)
+    }
   }
 
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC13")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.21")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "1.3.0")


### PR DESCRIPTION
- Automatic derivation for ConfDecoder
- Automatic derivation of Surface[T], to auto-generate docs and --help

I debated a lot with myself whether I should sunset this project or not.
On one hand, I would love to minimize my maintenance burden by building
on top of existing libraries. It would make a lot of sense to stop
metaconfig altogether and use something like Circe. On the other hand,
I feel like I would end up doing as much work building custom
configuration features on top of circe. The default circe error messages
are not so helpful, and I would need some way to automatically fail on
typos.

I decided to first experiment with implementing these macros on top of
metaconfig.Conf and see how it goes. This comit does not eliminate the
potential to switch to circe later down the road and the macros in this
repo can easily be tweaked when that happens. For now, this commit
solves two urgent needs in scalafix without breaking any existing code

* writing configuration for scalafix rules is plain tedious
* keeping the docs on configuration options up-to-date on the website
  is hard, causing a bad user experience. With the new
  metadoc.Surface[T], it should be possible to programmatically generate
  docs from the annotations on case fields.

I would love to experiement with a metaconfig-cli helper to convert command
line arguments to metaconfig.Conf. This would make it possible to drop
the dependency on case-app (and shapeless transitively).

A lot of work in this PR is inspired by code from other repos, including

- circe
- airframe
- case-app
- monix