### PR TITLE
Add ConfEncoder and ConfCodec typeclasses

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+Please refer to the [Scalameta](https://github.com/scalameta/scalameta/blob/master/CONTRIBUTING.md)
+contributing guidelines to learn more about how to report tickets and open pull requests.
+
+## Website
+
+The website is built with [GitBook](https://www.npmjs.com/package/gitbook-cli).
+To install GitBook
+
+```
+npm install -g gitbook-cli
+```
+
+Then inside sbt
+
+```
+> website/makeSite
+```
+This will generate a static GitBook site in the directory `website/target/site`.
+
+After running `website/makeSite`, preview the website locally with
+
+```
+cd website/target/site
+gitbook serve
+```
+And open [localhost:4000](http://localhost:4000).
+
+

--- a/build.sbt
+++ b/build.sbt
@@ -57,9 +57,12 @@ lazy val website = project
 lazy val baseSettings = Seq(
   scalaVersion := ScalaVersions.head,
   crossScalaVersions := ScalaVersions,
+  testOptions.in(Test) +=
+    Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "2"),
   libraryDependencies ++= List(
-    "org.scalacheck" %%% "scalacheck" % "1.13.5" % Test,
-    "org.scalatest" %%% "scalatest" % "3.0.2" % Test
+    "org.scalatest" %%% "scalatest" % "3.0.2" % Test,
+    "org.scalacheck" %% "scalacheck" % "1.14.0" % Test,
+    "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % Test
   )
 )
 

--- a/metaconfig-core/shared/src/main/scala/metaconfig/ConfCodec.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/ConfCodec.scala
@@ -1,0 +1,26 @@
+package metaconfig
+
+import scala.language.higherKinds
+
+trait ConfCodec[A] extends ConfDecoder[A] with ConfEncoder[A] { self =>
+  def bimap[B](in: B => A, out: A => B): ConfCodec[B] = new ConfCodec[B] {
+    override def write(value: B): Conf = self.write(in(value))
+    override def read(conf: Conf): Configured[B] = self.read(conf).map(out)
+  }
+}
+
+object ConfCodec {
+  def apply[A](implicit ev: ConfCodec[A]): ConfCodec[A] = ev
+  implicit def EncoderDecoderToCodec[A](
+      implicit
+      encode: ConfEncoder[A],
+      decode: ConfDecoder[A]): ConfCodec[A] = new ConfCodec[A] {
+    override def write(value: A): Conf = encode.write(value)
+    override def read(conf: Conf): Configured[A] = decode.read(conf)
+  }
+
+  val IntCodec: ConfCodec[Int] = ConfCodec[Int]
+  val StringCodec: ConfCodec[String] = ConfCodec[String]
+  val BooleanCodec: ConfCodec[Boolean] = ConfCodec[Boolean]
+
+}

--- a/metaconfig-core/shared/src/main/scala/metaconfig/ConfDecoder.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/ConfDecoder.scala
@@ -40,8 +40,11 @@ trait ConfDecoder[A] { self =>
 }
 
 object ConfDecoder {
+
+  @deprecated("Use ConfDecoder[T].read instead", "0.6.1")
   def decode[T](conf: Conf)(implicit ev: ConfDecoder[T]): Configured[T] =
     ev.read(conf)
+
   def apply[T](implicit ev: ConfDecoder[T]): ConfDecoder[T] = ev
 
   // TODO(olafur) remove in favor of instanceExpect.

--- a/metaconfig-core/shared/src/main/scala/metaconfig/ConfEncoder.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/ConfEncoder.scala
@@ -1,0 +1,52 @@
+package metaconfig
+
+import scala.language.higherKinds
+
+trait ConfEncoder[A] { self =>
+  def write(value: A): Conf
+
+  final def contramap[B](f: B => A): ConfEncoder[B] = new ConfEncoder[B] {
+    override def write(value: B): Conf = self.write(f(value))
+  }
+}
+
+object ConfEncoder {
+
+  def apply[A](implicit ev: ConfEncoder[A]): ConfEncoder[A] = ev
+
+  def instance[A](f: A => Conf): ConfEncoder[A] = new ConfEncoder[A] {
+    override def write(value: A): Conf = f(value)
+  }
+
+  implicit val BooleanEncoder: ConfEncoder[Boolean] =
+    new ConfEncoder[Boolean] {
+      override def write(value: Boolean): Conf = Conf.Bool(value)
+    }
+
+  implicit val IntEncoder: ConfEncoder[Int] =
+    new ConfEncoder[Int] {
+      override def write(value: Int): Conf = Conf.Num(value)
+    }
+
+  implicit val StringEncoder: ConfEncoder[String] =
+    new ConfEncoder[String] {
+      override def write(value: String): Conf = Conf.Str(value)
+    }
+
+  implicit def SeqEncoder[A, C[x] <: Seq[x]](
+      implicit ev: ConfEncoder[A]): ConfEncoder[C[A]] =
+    new ConfEncoder[C[A]] {
+      override def write(value: C[A]): Conf = {
+        Conf.Lst(value.iterator.map(ev.write).toList)
+      }
+    }
+
+  implicit def MapEncoder[A](
+      implicit ev: ConfEncoder[A]): ConfEncoder[Map[String, A]] =
+    new ConfEncoder[Map[String, A]] {
+      override def write(value: Map[String, A]): Conf = {
+        Conf.Obj(value.mapValues(ev.write).toList)
+      }
+    }
+
+}

--- a/metaconfig-core/shared/src/main/scala/metaconfig/generic/package.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/generic/package.scala
@@ -7,4 +7,8 @@ package object generic {
     macro metaconfig.internal.Macros.deriveSurfaceImpl[T]
   def deriveDecoder[T](default: T): ConfDecoder[T] =
     macro metaconfig.internal.Macros.deriveConfDecoderImpl[T]
+  def deriveEncoder[T]: ConfEncoder[T] =
+    macro metaconfig.internal.Macros.deriveConfEncoderImpl[T]
+  def deriveCodec[T](default: T): ConfCodec[T] =
+    macro metaconfig.internal.Macros.deriveConfCodecImpl[T]
 }

--- a/metaconfig-core/shared/src/test/scala/metaconfig/AllTheAnnotations.scala
+++ b/metaconfig-core/shared/src/test/scala/metaconfig/AllTheAnnotations.scala
@@ -1,0 +1,60 @@
+package metaconfig
+
+import metaconfig.annotation.Deprecated
+import metaconfig.annotation.DeprecatedName
+import metaconfig.annotation.Description
+import metaconfig.annotation.ExampleValue
+import metaconfig.annotation.ExtraName
+import metaconfig.annotation.SinceVersion
+import metaconfig.generic.Surface
+import org.scalacheck.Arbitrary
+
+case class AllTheAnnotations(
+    @Description("descriptioon")
+    @ExampleValue("value")
+    @ExampleValue("value2")
+    @ExtraName("extraName")
+    @ExtraName("extraName2")
+    @DeprecatedName("deprecatedName", "Use x instead", "2.0")
+    @DeprecatedName("deprecatedName2", "Use y instead", "3.0")
+    @SinceVersion("2.1")
+    @Description("Description")
+    @Deprecated("Use newFeature instead", "2.1")
+    number: Int = 2,
+    string: String = "string",
+    lst: List[String] = Nil
+)
+
+object AllTheAnnotations {
+  implicit lazy val fields: Surface[AllTheAnnotations] =
+    generic.deriveSurface[AllTheAnnotations]
+  implicit lazy val decoder: ConfDecoder[AllTheAnnotations] =
+    generic.deriveDecoder[AllTheAnnotations](AllTheAnnotations()).noTypos
+  implicit val encoder: ConfEncoder[AllTheAnnotations] =
+    generic.deriveEncoder[AllTheAnnotations]
+}
+
+case class OneParam(param: Int)
+object OneParam {
+  implicit val surface: Surface[OneParam] = generic.deriveSurface[OneParam]
+}
+
+case class HasOption(b: Option[Int] = None)
+object HasOption {
+  implicit val surface = generic.deriveSurface[HasOption]
+  implicit val decoder = generic.deriveDecoder[HasOption](HasOption())
+}
+
+case class Curry(a: Int)(b: String)
+object Curry {
+  implicit val surface: Surface[Curry] = generic.deriveSurface[Curry]
+}
+case class NoCurry(a: Int)
+object NoCurry {
+  implicit val surface: Surface[NoCurry] = generic.deriveSurface[NoCurry]
+}
+case class NoParam()
+object NoParam {
+  implicit val surface: Surface[NoParam] = generic.deriveSurface[NoParam]
+  implicit val encoder: ConfEncoder[NoParam] = generic.deriveEncoder
+}

--- a/metaconfig-core/shared/src/test/scala/metaconfig/CodecProps.scala
+++ b/metaconfig-core/shared/src/test/scala/metaconfig/CodecProps.scala
@@ -1,0 +1,36 @@
+package metaconfig
+
+import metaconfig.generic.Surface
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Properties
+import org.scalacheck.ScalacheckShapeless._
+
+case class Inner(a: String = "a", b: Boolean = true)
+object Inner {
+  implicit val surface: Surface[Inner] = generic.deriveSurface[Inner]
+  implicit val codec: ConfCodec[Inner] = generic.deriveCodec(Inner())
+}
+
+case class Outer(inner: Inner = Inner(), c: Int = 0)
+object Outer {
+  implicit val surface: Surface[Outer] = generic.deriveSurface
+  implicit val codec: ConfCodec[Outer] = generic.deriveCodec(Outer())
+}
+
+class CodecProps extends Properties("Codec") {
+
+  def checkRoundtrip[T: ConfCodec](a: T): Boolean = {
+    val conf = ConfEncoder[T].write(a)
+    val b = ConfDecoder[T].read(conf).get
+    a == b
+  }
+
+  property("roundtrip AllTheAnnotations") = forAll { a: AllTheAnnotations =>
+    checkRoundtrip(a)
+  }
+
+  property("roundtrip Outer") = forAll { a: Outer =>
+    checkRoundtrip(a)
+  }
+
+}

--- a/metaconfig-core/shared/src/test/scala/metaconfig/DeriveConfCodecSuite.scala
+++ b/metaconfig-core/shared/src/test/scala/metaconfig/DeriveConfCodecSuite.scala
@@ -1,0 +1,20 @@
+package metaconfig
+
+import org.scalatest.FunSuite
+
+class DeriveConfCodecSuite extends FunSuite {
+
+  def check[T: ConfCodec](name: String, original: T): Unit = {
+    test(name) {
+      val conf = ConfEncoder[T].write(original)
+      val obtained = ConfDecoder[T].read(conf).get
+      assert(obtained == original)
+    }
+  }
+
+  check[AllTheAnnotations](
+    "basic",
+    AllTheAnnotations()
+  )
+
+}

--- a/metaconfig-core/shared/src/test/scala/metaconfig/DeriveConfEncoderSuite.scala
+++ b/metaconfig-core/shared/src/test/scala/metaconfig/DeriveConfEncoderSuite.scala
@@ -1,0 +1,34 @@
+package metaconfig
+
+import org.scalatest.FunSuite
+
+class DeriveConfEncoderSuite extends FunSuite {
+
+  def check[T: ConfEncoder](name: String, original: T, expected: Conf): Unit = {
+    test(name) {
+      val obtained = ConfEncoder[T].write(original)
+      assert(obtained == expected)
+    }
+  }
+
+  check(
+    "noparam",
+    NoParam(),
+    Conf.Obj()
+  )
+
+  check(
+    "annotations",
+    AllTheAnnotations(
+      number = 3,
+      string = "foo",
+      lst = List("lst")
+    ),
+    Conf.Obj(
+      "number" -> Conf.Num(3),
+      "string" -> Conf.Str("foo"),
+      "lst" -> Conf.Lst(Conf.Str("foo"))
+    )
+  )
+
+}


### PR DESCRIPTION
This is necessary to generate examples in the scalafmt website.
Currently, the scalafmt website uses a `toHocon` method that is
generated by the old macro annotations to pretty-print the configuration
values. Now that the macro annotations are gone we need ability to
convert classes into `Conf`.