### PR TITLE
Implement hocon printer and conf patch.

### DIFF
--- a/metaconfig-core/jvm/src/test/scala/metaconfig/HoconPrinterSuite.scala
+++ b/metaconfig-core/jvm/src/test/scala/metaconfig/HoconPrinterSuite.scala
@@ -1,0 +1,56 @@
+package metaconfig
+
+import org.scalatest.FunSuite
+import scala.meta.testkit.DiffAssertions
+
+class HoconPrinterSuite extends FunSuite with DiffAssertions {
+
+  def check(original: Conf, expected: String): Unit = {
+    test(original.toString()) {
+      val obtained = Conf.printHocon(original)
+      assertNoDiff(obtained, expected)
+    }
+  }
+
+  check(
+    Conf.Obj(
+      "a" -> Conf.Bool(true),
+      "b" -> Conf.Null(),
+      "c" -> Conf.Num(1),
+      "d" -> Conf.Lst(Conf.Str("2"), Conf.Str("")),
+      "e" -> Conf.Obj("f" -> Conf.Num(3)),
+      "f.g" -> Conf.Num(2)
+    ),
+    """|a = true
+       |b = null
+       |c = 1
+       |d = [
+       |  "2"
+       |  ""
+       |]
+       |e.f = 3
+       |"f.g" = 2
+       |""".stripMargin.trim
+  )
+
+  check(
+    Conf.Obj(
+      "a" -> Conf.Lst(Conf.Str("b.c"))
+    ),
+    """
+      |a = [
+      |  "b.c"
+      |]
+    """.stripMargin.trim
+  )
+
+  check(
+    Conf.Obj(
+      "a" -> Conf.Obj("b.c" -> Conf.Str("d"))
+    ),
+    """
+      |a."b.c" = d
+    """.stripMargin.trim
+  )
+
+}

--- a/metaconfig-core/jvm/src/test/scala/metaconfig/PatchSuite.scala
+++ b/metaconfig-core/jvm/src/test/scala/metaconfig/PatchSuite.scala
@@ -1,0 +1,40 @@
+package metaconfig
+
+import org.scalatest.FunSuite
+import scala.meta.testkit.DiffAssertions
+
+class PatchSuite extends FunSuite with DiffAssertions {
+
+  def ignore(a: Conf, b: Conf, expected: String): Unit =
+    ignore(a.toString()) {}
+  def check(original: Conf, revised: Conf, expected: String): Unit =
+    test(original.toString()) {
+      val obtained = Conf.printHocon(Conf.patch(original, revised))
+      assertNoDiff(obtained, expected)
+    }
+
+  check(
+    Conf.Obj(
+      "a" -> Conf.Str("b"),
+      "c" -> Conf.Str("d") // ignored
+    ),
+    Conf.Obj(
+      "a" -> Conf.Str("c"),
+      "e" -> Conf.Str("f")
+    ),
+    """a = c
+      |e = f
+    """.stripMargin.trim
+  )
+
+  check(
+    Conf.Obj("a" -> Conf.Lst(Conf.Str("b"), Conf.Str("c"))),
+    Conf.Obj("a" -> Conf.Lst(Conf.Str("c"), Conf.Str("d"))),
+    """
+      |a = [
+      |  c
+      |  d
+      |]
+    """.stripMargin.trim
+  )
+}

--- a/metaconfig-core/shared/src/main/scala/metaconfig/Conf.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/Conf.scala
@@ -7,6 +7,8 @@ import metaconfig.generic.Setting
 import metaconfig.generic.Settings
 import metaconfig.internal.CliParser
 import metaconfig.internal.ConfGet
+import metaconfig.internal.ConfPatch
+import metaconfig.internal.HoconPrinter
 
 sealed abstract class Conf extends Product with Serializable {
   def dynamic: ConfDynamic = ConfDynamic(Configured.Ok(this))
@@ -16,12 +18,8 @@ sealed abstract class Conf extends Product with Serializable {
   final def kind: String = ConfOps.kind(this)
   final def show: String = ConfOps.show(this)
   final def foreach(f: Conf => Unit): Unit = ConfOps.foreach(this)(f)
+  @deprecated("No longer supported", "0.7.1")
   final def diff(other: Conf): Option[(Conf, Conf)] = ConfOps.diff(this, other)
-  // Customize equals because we subtype classes (which is bad)
-  override final def equals(obj: scala.Any): Boolean = obj match {
-    case other: Conf => ConfOps.diff(this, other).isEmpty
-    case _ => false
-  }
   final override def toString: String = show
   def as[T](implicit ev: ConfDecoder[T]): Configured[T] =
     ev.read(this)
@@ -45,6 +43,7 @@ object Conf {
   def fromNumberOrString(str: String): Conf =
     Try(fromBigDecimal(BigDecimal(str.toDouble))).getOrElse(fromString(str))
   def fromString(str: String): Conf = Conf.Str(str)
+
   def parseCliArgs[T](args: List[String])(
       implicit settings: Settings[T]): Configured[Conf] =
     CliParser.parseArgs[T](args)
@@ -61,6 +60,15 @@ object Conf {
       implicit parser: MetaconfigParser): Configured[Conf] =
     parser.fromInput(input)
 
+  /** Pretty-print this value as a HOCON string. */
+  def printHocon[T: ConfEncoder](value: T): String = {
+    HoconPrinter.toHocon(value).render(100)
+  }
+
+  /** Produce a minimal Conf that when merged with original yields revised. **/
+  def patch(original: Conf, revised: Conf): Conf =
+    ConfPatch.patch(original, revised)
+
   case class Null() extends Conf
   case class Str(value: String) extends Conf
   case class Num(value: BigDecimal) extends Conf
@@ -68,6 +76,13 @@ object Conf {
   case class Lst(values: List[Conf]) extends Conf
   object Lst { def apply(values: Conf*): Lst = Lst(values.toList) }
   case class Obj(values: List[(String, Conf)]) extends Conf {
+    override final def equals(obj: scala.Any): Boolean =
+      this.eq(obj.asInstanceOf[AnyRef]) || {
+        obj match {
+          case o: Conf.Obj => map equals o.map // Ignore key ordering.
+          case _ => false
+        }
+      }
     lazy val map: Map[String, Conf] = values.toMap
     def field(key: String): Option[Conf] = map.get(key)
     def keys: List[String] = values.map(_._1)
@@ -122,12 +137,15 @@ object ConfOps {
           }
           .headOption
     case (Lst(l1), Lst(l2)) =>
-      l1.zip(l1)
-        .flatMap {
-          case (c1, c2) =>
-            diff(c1, c2)
-        }
-        .headOption
+      if (l1.lengthCompare(l2.length) != 0) Some(a -> b)
+      else {
+        l1.zip(l1)
+          .flatMap {
+            case (c1, c2) =>
+              diff(c1, c2)
+          }
+          .headOption
+      }
     case (Str(x), Str(y)) => if (x != y) Some(a -> b) else None
     case (Bool(x), Bool(y)) => if (x != y) Some(a -> b) else None
     case (Num(x), Num(y)) => if (x != y) Some(a -> b) else None
@@ -231,24 +249,5 @@ object ConfOps {
     case Lst(_) => "List[T]"
     case Obj(_) => "Map[K, V]"
     case Null() => "Null"
-  }
-}
-
-object Extractors {
-  object Number {
-    def unapply(arg: String): Option[BigDecimal] =
-      Try(BigDecimal(arg)).toOption
-  }
-  object NestedKey {
-    def unapply(arg: String): Option[(String, String)] = {
-      val idx = arg.indexOf('.')
-      if (idx == -1) None
-      else {
-        arg.splitAt(idx) match {
-          case (_, "") => None
-          case (a, b) => Some(a -> b.stripPrefix("."))
-        }
-      }
-    }
   }
 }

--- a/metaconfig-core/shared/src/main/scala/metaconfig/Conf.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/Conf.scala
@@ -69,6 +69,10 @@ object Conf {
   def patch(original: Conf, revised: Conf): Conf =
     ConfPatch.patch(original, revised)
 
+  /** Applies the patch configuration on top of original. */
+  def applyPatch(original: Conf, patch: Conf): Conf =
+    ConfOps.merge(original, patch)
+
   case class Null() extends Conf
   case class Str(value: String) extends Conf
   case class Num(value: BigDecimal) extends Conf

--- a/metaconfig-core/shared/src/main/scala/metaconfig/ConfEncoder.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/ConfEncoder.scala
@@ -18,10 +18,14 @@ object ConfEncoder {
     override def write(value: A): Conf = f(value)
   }
 
-  implicit val ConfEncoder: ConfEncoder[Conf] =
+  private val GenericConfEncoder: ConfEncoder[Conf] =
     new ConfEncoder[Conf] {
       override def write(value: Conf): Conf = value
     }
+
+  // Invariant type-classes don't work unfortunately so we do this work by hand.
+  implicit def ConfEncoder[T <: Conf]: ConfEncoder[T] =
+    GenericConfEncoder.asInstanceOf[ConfEncoder[T]]
 
   implicit val BooleanEncoder: ConfEncoder[Boolean] =
     new ConfEncoder[Boolean] {

--- a/metaconfig-core/shared/src/main/scala/metaconfig/ConfEncoder.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/ConfEncoder.scala
@@ -18,6 +18,11 @@ object ConfEncoder {
     override def write(value: A): Conf = f(value)
   }
 
+  implicit val ConfEncoder: ConfEncoder[Conf] =
+    new ConfEncoder[Conf] {
+      override def write(value: Conf): Conf = value
+    }
+
   implicit val BooleanEncoder: ConfEncoder[Boolean] =
     new ConfEncoder[Boolean] {
       override def write(value: Boolean): Conf = Conf.Bool(value)

--- a/metaconfig-core/shared/src/main/scala/metaconfig/Extractors.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/Extractors.scala
@@ -1,0 +1,22 @@
+package metaconfig
+
+import scala.util.Try
+
+object Extractors {
+  object Number {
+    def unapply(arg: String): Option[BigDecimal] =
+      Try(BigDecimal(arg)).toOption
+  }
+  object NestedKey {
+    def unapply(arg: String): Option[(String, String)] = {
+      val idx = arg.indexOf('.')
+      if (idx == -1) None
+      else {
+        arg.splitAt(idx) match {
+          case (_, "") => None
+          case (a, b) => Some(a -> b.stripPrefix("."))
+        }
+      }
+    }
+  }
+}

--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/ConfPatch.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/ConfPatch.scala
@@ -1,0 +1,24 @@
+package metaconfig.internal
+
+import metaconfig.Conf
+
+object ConfPatch {
+  def patch(original: Conf, revised: Conf): Conf = (original, revised) match {
+    case (Conf.Obj(a), Conf.Obj(b)) =>
+      Conf.Obj(b.flatMap {
+        case kv @ (k, v) =>
+          if (a.contains(kv)) Nil
+          else {
+            a.find(_._1 == k) match {
+              case Some((_, v1)) =>
+                (k, patch(v1, v)) :: Nil
+              case _ =>
+                kv :: Nil
+            }
+          }
+      })
+    case (a, b) =>
+      b
+  }
+
+}

--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/HoconPrinter.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/HoconPrinter.scala
@@ -1,0 +1,84 @@
+package metaconfig.internal
+
+import metaconfig.Conf
+import metaconfig.ConfEncoder
+import org.typelevel.paiges.Doc._
+import org.typelevel.paiges.Doc
+
+object HoconPrinter {
+
+  def toHocon[T: ConfEncoder](value: T): Doc = {
+    toHocon(ConfEncoder[T].write(value))
+  }
+
+  def toHocon(conf: Conf): Doc = {
+    def loop(c: Conf): Doc = {
+      c match {
+        case Conf.Null() => text("null")
+        case Conf.Num(num) => str(num)
+        case Conf.Str(str) => quoteString(str)
+        case Conf.Bool(bool) => str(bool)
+        case Conf.Lst(lst) =>
+          if (lst.isEmpty) text("[]")
+          else {
+            val parts = intercalate(line, lst.map {
+              case c: Conf.Obj =>
+                wrap('{', '}', loop(c))
+              case x => loop(x)
+            })
+            wrap('[', ']', parts)
+          }
+        case Conf.Obj(obj) =>
+          intercalate(line, obj.map {
+            case (k, v) =>
+              text(k) + text(" = ") + loop(v)
+          })
+      }
+    }
+
+    loop(flatten(conf))
+  }
+
+  def flatten(c: Conf): Conf = c match {
+    case Conf.Obj(obj) =>
+      val flattened = obj.map {
+        case (k, v) => (k, flatten(v))
+      }
+      val next = flattened.flatMap {
+        case (key, Conf.Obj(nested)) =>
+          nested.map {
+            case (k, v) => s"${quote(key)}.$k" -> v
+          }
+        case (key, value) => (quote(key), value) :: Nil
+      }
+      Conf.Obj(next)
+    case Conf.Lst(lst) =>
+      Conf.Lst(lst.map(flatten))
+    case x => x
+  }
+
+  private def quote(key: String): String =
+    if (key.indexOf('.') < 0) key
+    else "\"" + key + "\""
+
+  private val quote = char('"')
+
+  // Spec is here:
+  // https://github.com/lightbend/config/blob/master/HOCON.md#unquoted-strings
+  // but this method is conservative and quotes if the string contains non-letter characters
+  private def needsQuote(str: String): Boolean =
+    str.isEmpty ||
+      str.startsWith("true") ||
+      str.startsWith("false") ||
+      str.startsWith("null") ||
+      str.exists(!_.isLetter)
+
+  private def quoteString(str: String): Doc =
+    if (needsQuote(str)) quote + text(str) + quote
+    else text(str)
+
+  private def wrap(open: Char, close: Char, doc: Doc): Doc = {
+    (char(open) + line + doc).nested(2) + line + char(close)
+  }
+
+}

--- a/metaconfig-core/shared/src/test/scala/metaconfig/DeriveConfEncoderSuite.scala
+++ b/metaconfig-core/shared/src/test/scala/metaconfig/DeriveConfEncoderSuite.scala
@@ -27,7 +27,7 @@ class DeriveConfEncoderSuite extends FunSuite {
     Conf.Obj(
       "number" -> Conf.Num(3),
       "string" -> Conf.Str("foo"),
-      "lst" -> Conf.Lst(Conf.Str("foo"))
+      "lst" -> Conf.Lst(Conf.Str("lst"))
     )
   )
 

--- a/metaconfig-core/shared/src/test/scala/metaconfig/EqualitySuite.scala
+++ b/metaconfig-core/shared/src/test/scala/metaconfig/EqualitySuite.scala
@@ -1,0 +1,36 @@
+package metaconfig
+
+import org.scalatest.FunSuite
+
+class EqualitySuite extends FunSuite {
+  def checkNotEqual(a: Conf, b: Conf): Unit =
+    test("ne " + a.toString) {
+      assert(a != b)
+    }
+
+  def checkEqual(a: Conf, b: Conf): Unit =
+    test("eq " + a.toString) {
+      assert(a == b)
+    }
+
+  checkNotEqual(
+    Conf.Lst(Conf.Str("a"), Conf.Str("b")),
+    Conf.Lst(Conf.Str("a"))
+  )
+
+  checkEqual(
+    Conf.Str("a"),
+    Conf.Str("a").withPos(Position.Range(Input.String("a"), 0, 1))
+  )
+
+  checkNotEqual(
+    Conf.Str("b"),
+    Conf.Str("c")
+  )
+
+  checkEqual(
+    Conf.Obj("a" -> Conf.Str("b"), "b" -> Conf.Str("c")),
+    Conf.Obj("b" -> Conf.Str("c"), "a" -> Conf.Str("b"))
+  )
+
+}

--- a/metaconfig-hocon/jvm/src/test/scala/metaconfig/hocon/ConfProps.scala
+++ b/metaconfig-hocon/jvm/src/test/scala/metaconfig/hocon/ConfProps.scala
@@ -1,19 +1,23 @@
 package metaconfig.hocon
 
+import metaconfig.ConfOps
 import metaconfig.ConfShow
 import metaconfig.Configured
 import org.scalacheck.Properties
 import org.scalacheck.Prop.forAll
-import org.scalacheck._
 import org.scalameta.logger
 
 class ConfProps extends Properties("Conf") {
   import metaconfig.Generators.argConfShow
-  property(".normalise is idempotent") = forAll { show: ConfShow =>
+  property("normalise is idempotent") = forAll { show: ConfShow =>
     val Configured.Ok(conf) = Hocon2Class.gimmeConfig(show.input)
-    val diff = conf.normalize.diff(conf.normalize.normalize)
-    if (diff.nonEmpty)
-      logger.elem(conf.normalize, conf.normalize.normalize, diff)
-    diff.isEmpty
+    val isEqual = conf.normalize == conf.normalize.normalize
+    if (!isEqual) {
+      val diff = ConfOps.diff(conf.normalize, conf.normalize.normalize)
+      if (diff.nonEmpty) {
+        logger.elem(conf.normalize, conf.normalize.normalize, diff)
+      }
+    }
+    isEqual
   }
 }

--- a/metaconfig-hocon/jvm/src/test/scala/metaconfig/hocon/HoconProps.scala
+++ b/metaconfig-hocon/jvm/src/test/scala/metaconfig/hocon/HoconProps.scala
@@ -8,7 +8,6 @@ import org.scalacheck._
 import org.scalameta.logger
 
 class HoconProps extends Properties("Compliance") {
-
   private def config2map(config: Config): Conf = {
     import scala.collection.JavaConverters._
     def loop(obj: Any): Conf = obj match {

--- a/metaconfig-typesafe-config/src/main/scala/metaconfig/typesafeconfig/TypesafeConfig2Class.scala
+++ b/metaconfig-typesafe-config/src/main/scala/metaconfig/typesafeconfig/TypesafeConfig2Class.scala
@@ -24,11 +24,10 @@ object TypesafeConfig2Class {
     val cache = mutable.Map.empty[Input, Array[Int]]
     def loop(value: ConfigValue): Conf = {
       val conf = value match {
-        case x: ConfigObject =>
-          Conf.Obj(
-            x.keySet().asScala.map(key => key -> loop(x.get(key))).toList)
-        case x: ConfigList =>
-          Conf.Lst(x.listIterator().asScala.map(loop).toList)
+        case obj: ConfigObject =>
+          Conf.Obj(obj.asScala.mapValues(loop).toList)
+        case lst: ConfigList =>
+          Conf.Lst(lst.listIterator().asScala.map(loop).toList)
         case _ =>
           value.unwrapped() match {
             case x: String => Conf.Str(x)

--- a/metaconfig-typesafe-config/src/test/scala/metaconfig/typesafeconfig/HoconPrinterProps.scala
+++ b/metaconfig-typesafe-config/src/test/scala/metaconfig/typesafeconfig/HoconPrinterProps.scala
@@ -1,0 +1,56 @@
+package metaconfig.typesafeconfig
+
+import metaconfig.Conf
+import metaconfig.ConfOps
+import metaconfig.ConfShow
+import org.scalacheck.Properties
+import org.scalameta.logger
+import org.scalatest.FunSuite
+import scala.meta.testkit.DiffAssertions
+import metaconfig.Generators.argConfShow
+import org.scalacheck.Prop.forAll
+
+object HoconPrinterProps {
+  def checkRoundtrip(conf: String): Boolean = {
+    val a = Conf.parseString(conf).get
+    val hocon = Conf.printHocon(a)
+    val b = Conf.parseString(hocon).get
+    val isEqual = a == b
+    if (!isEqual) {
+      pprint.log(a)
+      pprint.log(b)
+      logger.elem(conf, hocon, Conf.patch(a, b))
+    }
+    a == b
+  }
+
+}
+
+class HoconPrinterProps extends Properties("HoconPrinter") {
+  property("roundtrip") = forAll { conf: ConfShow =>
+    HoconPrinterProps.checkRoundtrip(conf.str)
+  }
+}
+
+class HoconPrinterRoundtripSuite extends FunSuite with DiffAssertions {
+  def ignore(conf: String): Unit = super.ignore(conf) {}
+  def checkRoundtrip(conf: String): Unit =
+    test(conf.take(100)) {
+      assert(HoconPrinterProps.checkRoundtrip(conf))
+    }
+
+  ignore(
+    """
+      |a.a = "d"
+      |a.bc = 9
+    """.stripMargin
+  )
+
+  checkRoundtrip(
+    """
+      |aa.bb = true
+      |aa.d = 3
+      |aa.aa = "cb"
+    """.stripMargin
+  )
+}

--- a/metaconfig-typesafe-config/src/test/scala/metaconfig/typesafeconfig/PatchProps.scala
+++ b/metaconfig-typesafe-config/src/test/scala/metaconfig/typesafeconfig/PatchProps.scala
@@ -1,0 +1,57 @@
+package metaconfig.typesafeconfig
+
+import metaconfig.Conf
+import metaconfig.ConfOps
+import metaconfig.ConfShow
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Properties
+import org.scalameta.logger
+import org.scalatest.FunSuite
+import scala.meta.testkit.DiffAssertions
+import metaconfig.Generators.argConfShow
+
+object PatchProps {
+  // asserts that applying
+  def checkPatch(a: String, b: String): Boolean = {
+    val original = Conf.parseString(a).get
+    val revised = Conf.parseString(b).get
+    val patch = Conf.patch(original, revised)
+    val expected = ConfOps.merge(original, revised)
+    val obtained = ConfOps.merge(original, patch)
+    if (obtained != expected) {
+      logger.elem(
+        obtained,
+        expected,
+        patch.toString,
+        Conf.patch(obtained, expected)
+      )
+    }
+    obtained == expected
+  }
+}
+
+class PatchProps extends Properties("Patch") {
+
+  property("roundtrip") = forAll { (a: ConfShow, b: ConfShow) =>
+    PatchProps.checkPatch(a.str, b.str)
+  }
+
+}
+class PatchPropsSuite extends FunSuite with DiffAssertions {
+  def check(a: String, b: String): Unit = {
+    test(a) { assert(PatchProps.checkPatch(a, b)) }
+  }
+
+  check(
+    """
+      |ad.da = true
+      |cc.bd = "dd"
+    """.stripMargin,
+    """
+      |
+      |ad.a.dc = false
+      |ad = "ad"
+    """.stripMargin
+  )
+
+}

--- a/metaconfig-typesafe-config/src/test/scala/metaconfig/typesafeconfig/PatchProps.scala
+++ b/metaconfig-typesafe-config/src/test/scala/metaconfig/typesafeconfig/PatchProps.scala
@@ -16,8 +16,8 @@ object PatchProps {
     val original = Conf.parseString(a).get
     val revised = Conf.parseString(b).get
     val patch = Conf.patch(original, revised)
-    val expected = ConfOps.merge(original, revised)
-    val obtained = ConfOps.merge(original, patch)
+    val expected = Conf.applyPatch(original, revised)
+    val obtained = Conf.applyPatch(original, patch)
     if (obtained != expected) {
       logger.elem(
         obtained,

--- a/metaconfig-typesafe-config/src/test/scala/metaconfig/typesafeconfig/TypesafeConfig2ClassTest.scala
+++ b/metaconfig-typesafe-config/src/test/scala/metaconfig/typesafeconfig/TypesafeConfig2ClassTest.scala
@@ -3,10 +3,7 @@ package metaconfig.typesafeconfig
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
-
 import metaconfig.Conf
-import metaconfig.Configured
-import org.scalameta.logger
 import org.scalatest.FunSuite
 
 class TypesafeConfig2ClassTest extends FunSuite {


### PR DESCRIPTION
The hocon printer is useful for documentation to show default values.
The patch is useful to show minimal configuration to apply on top of
default values.

The hocon printer is tested against the property that the printed config
parses into the same config object. Patch is tested against the property

```
merge(original, patch(original, revised)) == merge(original, revised)
```

While working on this I discovered quite a few serious equality bugs
that have now been fixed.