### PR TITLE
Prototype of schema generation using ujson

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,13 @@ lazy val `metaconfig-docs` = project
   )
   .dependsOn(`metaconfig-coreJVM`)
 
+lazy val `metaconfig-schema` = project
+  .settings(
+    allSettings,
+    libraryDependencies ++= Nil
+  )
+  .dependsOn(`metaconfig-coreJVM`)
+
 lazy val website = project
   .settings(
     allSettings,

--- a/metaconfig-schema/src/main/scala/metaconfig/schema/Schema.scala
+++ b/metaconfig-schema/src/main/scala/metaconfig/schema/Schema.scala
@@ -1,0 +1,49 @@
+package metaconfig.schema
+
+import metaconfig.generic.Setting
+import metaconfig.generic.Settings
+import ujson._
+
+object Schema {
+
+  def schema[T <: Product](
+      title: String,
+      description: String,
+      url: Option[String],
+      default: T)(implicit settings: Settings[T]): Js.Obj = {
+
+    val properties: List[(String, Js.Obj)] = settings.settings.map(fromSetting)
+    Js.Obj(
+      "$id" -> url.map(Js.Str).getOrElse(Js.Null),
+      "title" -> Js.Str(title),
+      "description" -> Js.Str(description),
+      "type" -> "object",
+      "properties" -> Js.Obj(properties: _*)
+    )
+  }
+
+  private def fromSetting(setting: Setting): (String, Js.Obj) = {
+    val properties =
+      setting.underlying.map(_.settings.map(fromSetting)).getOrElse(Nil)
+
+    setting.name -> Js.Obj(
+      "title" -> Js.Str(setting.name),
+      "description" -> setting.description.map(Js.Str).getOrElse(Js.Null),
+      "default" -> Js.Null, // TODO
+      // TODO: How should we handle required
+      "required" -> Js.False,
+      "type" -> toSchemaType(setting.tpe),
+      "properties" -> Js.Obj(properties: _*)
+    )
+  }
+
+  private def toSchemaType(tpe: String): Js.Str = tpe match {
+    case "Boolean" => "boolean"
+    case "Int" => "int"
+    case "Float" => "int"
+    case "List" => "array"
+    case "String" => "string"
+    case _ => "object"
+  }
+
+}

--- a/metaconfig-schema/src/main/scala/metaconfig/schema/Schema.scala
+++ b/metaconfig-schema/src/main/scala/metaconfig/schema/Schema.scala
@@ -12,7 +12,10 @@ object Schema {
       url: Option[String],
       default: T)(implicit settings: Settings[T]): Js.Obj = {
 
-    val properties: List[(String, Js.Obj)] = settings.settings.map(fromSetting)
+    val properties: List[(String, Js.Obj)] = settings.settings
+      .zip(default.productIterator.toIterable)
+      .map { case (s, v) => fromSetting(s, v) }
+
     Js.Obj(
       "$id" -> url.map(Js.Str).getOrElse(Js.Null),
       "title" -> Js.Str(title),
@@ -22,22 +25,55 @@ object Schema {
     )
   }
 
-  private def fromSetting(setting: Setting): (String, Js.Obj) = {
+  private def fromSetting(s: Setting, dv: Any) = dv match {
+    case p: Product => fromComplexSetting(s, p)
+    case v => fromSimpleSetting(s, v)
+  }
+
+  private def fromSimpleSetting(
+      setting: Setting,
+      defaultValue: Any): (String, Js.Obj) = {
+
+    setting.name -> Js.Obj(
+      "title" -> Js.Str(setting.name),
+      "description" -> setting.description.map(Js.Str).getOrElse(Js.Null),
+      "default" -> toJsonValue(defaultValue),
+      "required" -> Js.False, // TODO: How should we handle required
+      "type" -> toSchemaType(setting.tpe),
+      "properties" -> Js.Obj()
+    )
+  }
+
+  private def fromComplexSetting(
+      setting: Setting,
+      defaultValue: Product): (String, Js.Obj) = {
     val properties =
-      setting.underlying.map(_.settings.map(fromSetting)).getOrElse(Nil)
+      setting.underlying
+        .map(
+          _.settings
+            .zip(defaultValue.productIterator.toIterable)
+            .map { case (s, v) => fromSetting(s, v) }
+        )
+        .getOrElse(Nil)
 
     setting.name -> Js.Obj(
       "title" -> Js.Str(setting.name),
       "description" -> setting.description.map(Js.Str).getOrElse(Js.Null),
       "default" -> Js.Null, // TODO
-      // TODO: How should we handle required
-      "required" -> Js.False,
-      "type" -> toSchemaType(setting.tpe),
+      "required" -> Js.False, // TODO: How should we handle required
+      "type" -> "object",
       "properties" -> Js.Obj(properties: _*)
     )
   }
 
+  private def toJsonValue(value: Any): Js.Value = value match {
+    case i: Int => Js.Num(i)
+    case s: String => Js.Str(s)
+    case _ => Js.Null
+  }
+
   private def toSchemaType(tpe: String): Js.Str = tpe match {
+    // https://tools.ietf.org/html/draft-handrews-json-schema-01#section-4.2.1
     case "Boolean" => "boolean"
     case "Int" => "int"
     case "Float" => "int"

--- a/metaconfig-schema/src/main/scala/metaconfig/schema/Schema.scala
+++ b/metaconfig-schema/src/main/scala/metaconfig/schema/Schema.scala
@@ -75,8 +75,8 @@ object Schema {
   private def toSchemaType(tpe: String): Js.Str = tpe match {
     // https://tools.ietf.org/html/draft-handrews-json-schema-01#section-4.2.1
     case "Boolean" => "boolean"
-    case "Int" => "int"
-    case "Float" => "int"
+    case "Int" => "number"
+    case "Float" => "number"
     case "List" => "array"
     case "String" => "string"
     case _ => "object"

--- a/metaconfig-schema/src/test/scala/metaconfig/schema/SchemaSuite.scala
+++ b/metaconfig-schema/src/test/scala/metaconfig/schema/SchemaSuite.scala
@@ -66,7 +66,7 @@ class SchemaSuite extends org.scalatest.FunSuite {
           "description" -> Js.Null,
           "default" -> Js.Num(42),
           "required" -> Js.False,
-          "type" -> "int",
+          "type" -> "number",
           "properties" -> Js.Obj()
         ),
         "b" -> Js.Obj(

--- a/metaconfig-schema/src/test/scala/metaconfig/schema/SchemaSuite.scala
+++ b/metaconfig-schema/src/test/scala/metaconfig/schema/SchemaSuite.scala
@@ -19,7 +19,7 @@ class SchemaSuite extends org.scalatest.FunSuite {
       title = "Simple title",
       description = "Simple description",
       url = None,
-      default = Simple("Default"))
+      default = Simple("Default Value"))
 
     val expected = Js.Obj(
       "$id" -> Js.Null,
@@ -30,7 +30,7 @@ class SchemaSuite extends org.scalatest.FunSuite {
         "value" -> Js.Obj(
           "title" -> Js.Str("value"),
           "description" -> "A simple description",
-          "default" -> Js.Null,
+          "default" -> Js.Str("Default Value"),
           "required" -> Js.False,
           "type" -> "string",
           "properties" -> Js.Obj()
@@ -64,7 +64,7 @@ class SchemaSuite extends org.scalatest.FunSuite {
         "value" -> Js.Obj(
           "title" -> Js.Str("value"),
           "description" -> Js.Null,
-          "default" -> Js.Null,
+          "default" -> Js.Num(42),
           "required" -> Js.False,
           "type" -> "int",
           "properties" -> Js.Obj()
@@ -79,7 +79,7 @@ class SchemaSuite extends org.scalatest.FunSuite {
             "value" -> Js.Obj(
               "title" -> Js.Str("value"),
               "description" -> Js.Null,
-              "default" -> Js.Null,
+              "default" -> Js.Str("Hest"),
               "required" -> Js.False,
               "type" -> "string",
               "properties" -> Js.Obj()

--- a/metaconfig-schema/src/test/scala/metaconfig/schema/SchemaSuite.scala
+++ b/metaconfig-schema/src/test/scala/metaconfig/schema/SchemaSuite.scala
@@ -1,0 +1,95 @@
+package metaconfig.schema
+
+import metaconfig._
+import metaconfig.annotation._
+import ujson._
+
+class SchemaSuite extends org.scalatest.FunSuite {
+
+  test("Simple non-nested configs") {
+
+    case class Simple(
+        @Description("A simple description")
+        value: String
+    )
+
+    implicit val simpleSurface = generic.deriveSurface[Simple]
+
+    val schema = Schema.schema(
+      title = "Simple title",
+      description = "Simple description",
+      url = None,
+      default = Simple("Default"))
+
+    val expected = Js.Obj(
+      "$id" -> Js.Null,
+      "title" -> Js.Str("Simple title"),
+      "description" -> Js.Str("Simple description"),
+      "type" -> "object",
+      "properties" -> Js.Obj(
+        "value" -> Js.Obj(
+          "title" -> Js.Str("value"),
+          "description" -> "A simple description",
+          "default" -> Js.Null,
+          "required" -> Js.False,
+          "type" -> "string",
+          "properties" -> Js.Obj()
+        )
+      )
+    )
+
+    assert(schema == expected)
+  }
+
+  test("Complex nested configuration objects") {
+
+    case class A(value: Int, b: B)
+    case class B(value: String)
+
+    implicit val bSurface = generic.deriveSurface[B]
+    implicit val aSurface = generic.deriveSurface[A]
+
+    val schema = Schema.schema(
+      title = "Complex title",
+      description = "Complex description",
+      url = None,
+      default = A(42, B("Hest")))
+
+    val expected = Js.Obj(
+      "$id" -> Js.Null,
+      "title" -> Js.Str("Complex title"),
+      "description" -> Js.Str("Complex description"),
+      "type" -> "object",
+      "properties" -> Js.Obj(
+        "value" -> Js.Obj(
+          "title" -> Js.Str("value"),
+          "description" -> Js.Null,
+          "default" -> Js.Null,
+          "required" -> Js.False,
+          "type" -> "int",
+          "properties" -> Js.Obj()
+        ),
+        "b" -> Js.Obj(
+          "title" -> Js.Str("b"),
+          "description" -> Js.Null,
+          "default" -> Js.Null,
+          "required" -> Js.False,
+          "type" -> "object",
+          "properties" -> Js.Obj(
+            "value" -> Js.Obj(
+              "title" -> Js.Str("value"),
+              "description" -> Js.Null,
+              "default" -> Js.Null,
+              "required" -> Js.False,
+              "type" -> "string",
+              "properties" -> Js.Obj()
+            )
+          )
+        )
+      )
+    )
+
+    assert(schema == expected)
+  }
+
+}


### PR DESCRIPTION
**NOTE** This is a proof of concept. Simply opening this PR so we can chat about it :)

Things that I'm still missing

- [ ] Default values for product types (Would need to convert `Product` to `Js.Obj`)
- [ ] Handle required values. We could check if the `tpe` is `Option`.
- [ ] More tests (for example lists are missing)

Things I'm not super happy with

- [ ] There's quite a lot of runtime type checking. For example in
  `toSchemaType` and `toJsonValue` but I don't know how to avoid it TBH
- [ ] Share more code between `fromComplexSetting` and `fromSimpleSetting`