### PR TITLE
Allow customizing Setting.tpe via tprint

### DIFF
--- a/metaconfig-core/jvm/src/test/scala/metaconfig/internal/CliSuite.scala
+++ b/metaconfig-core/jvm/src/test/scala/metaconfig/internal/CliSuite.scala
@@ -11,8 +11,8 @@ class CliSuite extends FunSuite with DiffAssertions {
     println(obtained)
     val expected =
       """
-        |--in: String = "docs"                                           The input directory to generate the fox site.
-        |--out: String = "target/fox"                                    The output directory to generate the fox site.
+        |--in: String = "docs"                                  The input directory to generate the fox site.
+        |--out: String = "target/fox"                           The output directory to generate the fox site.
         |--cwd: String = "/tmp"
         |--repo-name: String = "olafurpg/fox"
         |--repo-url: String = "https://github.com/olafurpg/fox"
@@ -25,10 +25,10 @@ class CliSuite extends FunSuite with DiffAssertions {
         |--encoding: String = "UTF-8"
         |--config-path: String = "fox.conf"
         |--remaining-args: List[String] = []
-        |--conf: metaconfig.Conf = {}
-        |--site: metaconfig.internal.Site = {"foo": "foo", "custom": {}}
+        |--conf: Conf = {}
+        |--site: Site = {"foo": "foo", "custom": {}}
         |--foo: String = "foo"
-        |--custom: Map[String,String] = {}
+        |--custom: Map[String, String] = {}
       """.stripMargin
     assertNoDiff(obtained, expected)
   }

--- a/metaconfig-core/shared/src/main/scala/metaconfig/annotation/Annotations.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/annotation/Annotations.scala
@@ -21,3 +21,4 @@ final case class Repeated() extends StaticAnnotation
 final case class Inline() extends StaticAnnotation
 final case class Dynamic() extends StaticAnnotation
 final case class Hidden() extends StaticAnnotation
+final case class Flag() extends StaticAnnotation

--- a/metaconfig-core/shared/src/main/scala/metaconfig/generic/Setting.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/generic/Setting.scala
@@ -43,10 +43,12 @@ final class Setting(val field: Field) {
     annotations.exists(_.isInstanceOf[Dynamic])
   def isHidden: Boolean =
     annotations.exists(_.isInstanceOf[Hidden])
-  def isBoolean: Boolean = field.tpe == "Boolean"
+  def isBoolean: Boolean =
+    annotations.exists(_.isInstanceOf[Flag])
   @deprecated("Use isDynamic instead", "0.8.2")
   def isMap: Boolean = field.tpe.startsWith("Map")
-  def isConf: Boolean = field.tpe.startsWith("metaconfig.Conf")
+  @deprecated("Use isDynamic instead", "0.8.2")
+  def isConf: Boolean = field.tpe.contains("Conf")
   def alternativeNames: List[String] =
     extraNames ::: deprecatedNames.map(_.name)
   def allNames: List[String] = name :: alternativeNames

--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/Macros.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/Macros.scala
@@ -153,8 +153,14 @@ class Macros(val c: blackbox.Context) {
           } else {
             Nil
           }
+        val flag =
+          if (paramTpe <:< typeOf[Boolean]) {
+            q"new _root_.metaconfig.annotation.Flag" :: Nil
+          } else {
+            Nil
+          }
 
-        val finalAnnots = repeated ::: dynamic ::: baseAnnots
+        val finalAnnots = repeated ::: dynamic ::: flag ::: baseAnnots
         val fieldsParamTpe = c.internal.typeRef(
           NoPrefix,
           weakTypeOf[Surface[_]].typeSymbol,
@@ -167,10 +173,16 @@ class Macros(val c: blackbox.Context) {
           } else {
             q"$underlyingInferred.fields"
           }
+        val tprint = c.internal.typeRef(
+          NoPrefix,
+          weakTypeOf[pprint.TPrint[_]].typeSymbol,
+          paramTpe :: Nil
+        )
+        val tpeString = c.inferImplicitValue(tprint)
 
         val field = q"""new ${weakTypeOf[Field]}(
            ${param.name.decodedName.toString},
-           ${paramTpe.toString},
+           $tpeString.render,
            _root_.scala.List.apply(..$finalAnnots),
            $underlying
          )"""


### PR DESCRIPTION
This makes it possible to implement custom type printer for example in
command-line --help etc.