### PR TITLE
`Input.File` instances with same path but different content should not equal each other

### DIFF
--- a/metaconfig-core/shared/src/main/scala/metaconfig/Input.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/Input.scala
@@ -81,17 +81,21 @@ object Input {
     override def toString = s"""Input.VirtualFile("$path", "...")"""
   }
 
-  final case class File(file: Path, charset: Charset)
+  final case class File(file: Path, charset: Charset, contents: Predef.String)
       extends Input(
         file.toString,
-        new Predef.String(Files.readAllBytes(file), charset.name)
+        contents
       )
   object File {
     def apply(file: java.io.File): Input = {
-      Input.File(file.toPath, StandardCharsets.UTF_8)
+      Input.File(file.toPath)
     }
     def apply(path: Path): Input = {
-      Input.File(path, StandardCharsets.UTF_8)
+      Input.File(
+        path,
+        StandardCharsets.UTF_8,
+        new Predef.String(Files.readAllBytes(path), StandardCharsets.UTF_8)
+      )
     }
   }
 

--- a/metaconfig-sconfig/src/main/scala/metaconfig/sconfig/package.scala
+++ b/metaconfig-sconfig/src/main/scala/metaconfig/sconfig/package.scala
@@ -3,7 +3,7 @@ package metaconfig
 package object sconfig {
   implicit val sConfigMetaconfigParser = new MetaconfigParser {
     override def fromInput(input: Input): Configured[Conf] = input match {
-      case Input.File(path, _) =>
+      case Input.File(path, _, _) =>
         SConfig2Class.gimmeConfFromFile(path.toFile)
       case els =>
         SConfig2Class.gimmeConfFromString(new String(els.chars))

--- a/metaconfig-typesafe-config/src/main/scala/metaconfig/typesafeconfig/package.scala
+++ b/metaconfig-typesafe-config/src/main/scala/metaconfig/typesafeconfig/package.scala
@@ -3,7 +3,7 @@ package metaconfig
 package object typesafeconfig {
   implicit val typesafeConfigMetaconfigParser = new MetaconfigParser {
     override def fromInput(input: Input): Configured[Conf] = input match {
-      case Input.File(path, _) =>
+      case Input.File(path, _, _) =>
         TypesafeConfig2Class.gimmeConfFromFile(path.toFile)
       case els =>
         TypesafeConfig2Class.gimmeConfFromString(new String(els.chars))


### PR DESCRIPTION
This should allow changing a file in Scalafix, and seeing those changes reflected upon re-running.

Fixes https://github.com/olafurpg/metaconfig/issues/67