### PR TITLE
Add support for tab completions for any Metaconfig cli app

### DIFF
--- a/metaconfig-core/jvm/src/test/scala/metaconfig/cli/CliParserSuite.scala
+++ b/metaconfig-core/jvm/src/test/scala/metaconfig/cli/CliParserSuite.scala
@@ -1,4 +1,4 @@
-package metaconfig.internal
+package metaconfig.cli
 
 import java.nio.file.Paths
 import metaconfig.annotation._
@@ -261,8 +261,8 @@ class CliParserSuite extends BaseCliParserSuite {
 
   checkError(
     "positional-everywhere4",
-    "positional1" :: "--title" :: Nil,
-    "the argument '--title' requires a value but none was supplied"
+    "positional1" :: "--repo-url" :: Nil,
+    "the argument '--repo-url' requires a value but none was supplied"
   )
 
   checkError(

--- a/metaconfig-core/jvm/src/test/scala/metaconfig/cli/CliSuite.scala
+++ b/metaconfig-core/jvm/src/test/scala/metaconfig/cli/CliSuite.scala
@@ -1,4 +1,4 @@
-package metaconfig.internal
+package metaconfig.cli
 
 import metaconfig.generic
 import metaconfig.generic.Settings
@@ -7,7 +7,6 @@ import org.typelevel.paiges.Doc
 import metaconfig.annotation.Description
 import metaconfig.ConfCodec
 import metaconfig.generic.Surface
-import metaconfig.cli.Messages
 
 case class Markdownish(
     @Description(

--- a/metaconfig-core/jvm/src/test/scala/metaconfig/cli/TabCompletionSuite.scala
+++ b/metaconfig-core/jvm/src/test/scala/metaconfig/cli/TabCompletionSuite.scala
@@ -1,0 +1,175 @@
+package metaconfig.cli
+
+import munit.FunSuite
+import munit.TestOptions
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets
+import metaconfig.generic
+import metaconfig.annotation._
+import java.nio.file.Paths
+import java.nio.file.Path
+import metaconfig.ConfCodec
+import java.nio.file.Files
+import java.io.File
+
+class TabCompletionSuite extends FunSuite {
+
+  case class TabOptions(
+      @Description("The input directory to generate the fox site.")
+      @ExtraName("i")
+      in: Path = Paths.get("docs"),
+      out: Path = Paths.get("target").resolve("fox"),
+      custom: String = "",
+      @Hidden // should not appear in --help
+      hidden: Int = 87
+  )
+  object TabOptions {
+    implicit val surface = generic.deriveSurface[TabOptions]
+    implicit val codec: ConfCodec[TabOptions] =
+      generic.deriveCodec[TabOptions](TabOptions())
+  }
+  object TabCommand extends Command[TabOptions]("tab") {
+    override def complete(
+        context: TabCompletionContext
+    ): List[TabCompletionItem] = {
+      if (context.last.isEmpty()) List(TabCompletionItem("empty"))
+      else {
+        val setting = context.setting.map(_.name + "-").getOrElse("")
+        List(
+          TabCompletionItem(
+            "setting:" + context.setting.fold("")(s => s" ${s.name}")
+          ),
+          TabCompletionItem(
+            "secondLast:" + context.secondLast.fold("")(s => s" ${s}")
+          ),
+          TabCompletionItem(
+            s"last: ${context.last}"
+          )
+        )
+      }
+    }
+    def run(value: Value, app: CliApp): Int = 0
+  }
+  def check(
+      name: TestOptions,
+      userArgs: List[String],
+      expected: String
+  )(implicit loc: munit.Location): Unit = {
+    test(name) {
+      val pwd = Files.createTempDirectory("metaconfig")
+      Files.write(pwd.resolve("hello"), Array.emptyByteArray)
+      Files.write(pwd.resolve("goodbye"), Array.emptyByteArray)
+      val project = Files.createDirectories(pwd.resolve("project"))
+      Files.write(project.resolve("inner"), Array.emptyByteArray)
+      Files.write(project.resolve("outer"), Array.emptyByteArray)
+      val binaryName = "app"
+      val words = binaryName :: userArgs
+      val args: List[String] =
+        "tab-complete" ::
+          "--current" :: words.length.toString ::
+          "--format" :: "zsh" ::
+          words
+      val out = new ByteArrayOutputStream()
+      val print = new PrintStream(out)
+      val app = CliApp(
+        version = "1.0",
+        arguments = args,
+        binaryName = binaryName,
+        commands = List(
+          HelpCommand,
+          VersionCommand,
+          TabCommand,
+          TabCompleteCommand
+        ),
+        out = print,
+        workingDirectory = pwd
+      )
+      val exit = app.run(args)
+      assertEquals(exit, 0, out.toString())
+      val obtained = out.toString(StandardCharsets.UTF_8.name)
+      assertNoDiff(obtained, expected)
+    }
+  }
+
+  check(
+    "basic",
+    List("h"),
+    """|help
+       |version
+       |tab
+       |""".stripMargin
+  )
+
+  check(
+    "flag",
+    List("tab", "-"),
+    """|--custom
+       |--in
+       |--out
+       |""".stripMargin
+  )
+
+  check(
+    "path-empty",
+    List("tab", "--in", ""),
+    """|goodbye
+       |hello
+       |project/
+       |""".stripMargin.replace('/', File.separatorChar)
+  )
+
+  check(
+    "path-no-slash",
+    List("tab", "--in", "project"),
+    """|goodbye
+       |hello
+       |project/
+       |""".stripMargin.replace('/', File.separatorChar)
+  )
+
+  check(
+    "path-directory",
+    List("tab", "--in", "project" + File.separatorChar),
+    """|project/inner
+       |project/outer
+       |""".stripMargin.replace('/', File.separatorChar)
+  )
+
+  check(
+    "custom-empty",
+    List("tab", "--custom", ""),
+    "empty"
+  )
+
+  check(
+    "custom-non-empty",
+    List("tab", "--custom", "abba"),
+    """|setting: custom
+       |secondLast: --custom
+       |last: abba
+       |""".stripMargin
+  )
+
+  check(
+    "custom-non-empty",
+    List("tab", "--unknown", "abba"),
+    """|setting:
+       |secondLast: --unknown
+       |last: abba
+       |""".stripMargin
+  )
+
+  check(
+    "error-empty",
+    List("--unknown", "value"),
+    ""
+  )
+
+  check(
+    "error-empty",
+    List("--unknown", "value"),
+    ""
+  )
+
+}

--- a/metaconfig-core/shared/src/main/scala/metaconfig/ConfDecoder.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/ConfDecoder.scala
@@ -9,6 +9,8 @@ import metaconfig.Extractors.Number
 import metaconfig.generic.Settings
 import metaconfig.internal.CanBuildFromDecoder
 import metaconfig.internal.NoTyposDecoder
+import java.nio.file.Path
+import java.nio.file.Paths
 
 trait ConfDecoder[A] { self =>
 
@@ -96,6 +98,10 @@ object ConfDecoder {
       case Conf.Bool(x) => Ok(x)
       case Conf.Str("true" | "on" | "yes") => Ok(true)
       case Conf.Str("false" | "off" | "no") => Ok(false)
+    }
+  implicit lazy val pathConfDecoder: ConfDecoder[Path] =
+    stringConfDecoder.flatMap { path =>
+      Configured.fromExceptionThrowing(Paths.get(path))
     }
   implicit def canBuildFromOption[A](
       implicit ev: ConfDecoder[A],

--- a/metaconfig-core/shared/src/main/scala/metaconfig/ConfEncoder.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/ConfEncoder.scala
@@ -1,6 +1,7 @@
 package metaconfig
 
 import scala.language.higherKinds
+import java.nio.file.Path
 
 trait ConfEncoder[A] { self =>
   def write(value: A): Conf
@@ -51,6 +52,11 @@ object ConfEncoder {
   implicit val StringEncoder: ConfEncoder[String] =
     new ConfEncoder[String] {
       override def write(value: String): Conf = Conf.Str(value)
+    }
+
+  implicit lazy val PathEncoder: ConfEncoder[Path] =
+    new ConfEncoder[Path] {
+      override def write(value: Path): Conf = Conf.Str(value.toString())
     }
 
   implicit def IterableEncoder[A, C[x] <: Iterable[x]](

--- a/metaconfig-core/shared/src/main/scala/metaconfig/Configured.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/Configured.scala
@@ -1,5 +1,8 @@
 package metaconfig
 
+import scala.util.Failure
+import scala.util.Success
+
 sealed abstract class Configured[+A] extends Product with Serializable {
   import Configured._
   def getOrElse[B >: A](els: => B): B = this match {
@@ -46,6 +49,12 @@ object Configured {
   def notOk[T](error: ConfError): Configured[T] = NotOk(error)
   def error(message: String): Configured[Nothing] =
     ConfError.message(message).notOk
+  def fromExceptionThrowing[T](thunk: => T): Configured[T] = {
+    scala.util.Try(thunk) match {
+      case Failure(exception) => Configured.exception(exception)
+      case Success(value) => Configured.ok(value)
+    }
+  }
   def exception(
       exception: Throwable,
       stackSize: Int = 10

--- a/metaconfig-core/shared/src/main/scala/metaconfig/annotation/Annotations.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/annotation/Annotations.scala
@@ -23,3 +23,6 @@ final case class Dynamic() extends StaticAnnotation
 final case class Hidden() extends StaticAnnotation
 final case class Flag() extends StaticAnnotation
 final case class Section(name: String) extends StaticAnnotation
+final case class TabCompleteAsPath() extends StaticAnnotation
+final case class CatchInvalidFlags() extends StaticAnnotation
+final case class TabCompleteAsOneOf(options: String*) extends StaticAnnotation

--- a/metaconfig-core/shared/src/main/scala/metaconfig/cli/CliApp.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/cli/CliApp.scala
@@ -27,13 +27,13 @@ case class CliApp(
     environmentVariables: Map[String, String] = sys.env
 ) {
   def error(message: Str): Unit = {
-    out.println(Color.LightRed("error: ") ++ message)
+    err.println(Color.LightRed("error: ") ++ message)
   }
   def warn(message: Str): Unit = {
-    out.println(Color.LightYellow("warn: ") ++ message)
+    err.println(Color.LightYellow("warn: ") ++ message)
   }
   def info(message: Str): Unit = {
-    out.println(Color.LightBlue("info: ") ++ message)
+    err.println(Color.LightBlue("info: ") ++ message)
   }
 
   def run(args: List[String]): Int = {

--- a/metaconfig-core/shared/src/main/scala/metaconfig/cli/Command.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/cli/Command.scala
@@ -13,18 +13,20 @@ import metaconfig.generic.Settings
 import metaconfig.ConfDecoder
 
 abstract class Command[T](val name: String)(
-    implicit surface: Surface[T],
+    implicit val surface: Surface[T],
     confEncoder: ConfEncoder[T],
     confDecoder: ConfDecoder[T]
 ) { self =>
   type Value = T
 
   def run(value: Value, app: CliApp): Int
+  def complete(context: TabCompletionContext): List[TabCompletionItem] = Nil
   def description: Doc = Doc.empty
   def options: Doc = Doc.empty
   def usage: Doc = Doc.empty
   def examples: Doc = Doc.empty
   def extraNames: List[String] = Nil
+  def isHidden: Boolean = false
 
   final def settings: Settings[Value] = Settings[T]
   final def encoder: ConfEncoder[Value] = confEncoder

--- a/metaconfig-core/shared/src/main/scala/metaconfig/cli/HelpCommand.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/cli/HelpCommand.scala
@@ -32,6 +32,17 @@ class HelpCommand(
 ) extends Command[HelpOptions]("help") {
   override def description = Doc.paragraph("Print this help message")
   override def extraNames: List[String] = List("-h", "--help", "-help")
+  override def complete(
+      context: TabCompletionContext
+  ): List[TabCompletionItem] = {
+    if (context.arguments.length <= 1) {
+      context.app.commands
+        .filterNot(_.isHidden)
+        .map(c => TabCompletionItem(c.name))
+    } else {
+      Nil
+    }
+  }
   def run(options: HelpOptions, app: CliApp): Int = {
     options.subcommand match {
       case Nil =>

--- a/metaconfig-core/shared/src/main/scala/metaconfig/cli/TabCompleteCommand.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/cli/TabCompleteCommand.scala
@@ -1,0 +1,157 @@
+package metaconfig.cli
+
+import metaconfig.generic.Surface
+import scala.collection.immutable.Nil
+import metaconfig.generic.Settings
+import metaconfig.internal.CliParser
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
+import metaconfig.Conf
+import metaconfig.generic
+import metaconfig.internal.Case
+import java.nio.file.Path
+import scala.util.Try
+import metaconfig.generic.Setting
+
+object TabCompleteCommand extends Command[TabCompleteOptions]("tab-complete") {
+
+  override def isHidden: Boolean = true
+  def run(options: TabCompleteOptions, app: CliApp): Int = {
+    val isMissingTrailingEmptyString =
+      options.current.contains(options.arguments.length + 1)
+    val arguments =
+      if (isMissingTrailingEmptyString) options.arguments :+ ""
+      else options.arguments
+    arguments match {
+      case _ :: _ :: Nil =>
+        renderCompletions(app.commands.filterNot(_.isHidden).map(_.name), app)
+      case _ :: subcommandName :: head :: tail =>
+        app.commands.find(_.matchesName(subcommandName)).foreach { subcommand =>
+          renderSubcommandCompletions(subcommand, head, tail, options, app)
+        }
+      case _ =>
+    }
+    0
+  }
+
+  private def renderSubcommandCompletions(
+      subcommand: Command[_],
+      head: String,
+      tail: List[String],
+      options: TabCompleteOptions,
+      app: CliApp
+  ): Unit = {
+    val last = tail.lastOption.getOrElse(head)
+    val inlined = CliParser
+      .allSettings(Settings(subcommand.surface))
+      .filter(!_._2.isHidden)
+    val secondLast = (head :: tail).takeRight(2) match {
+      case flag :: last :: Nil => Some(flag)
+      case _ => None
+    }
+    val setting = secondLast.flatMap(
+      flag => inlined.get(Case.kebabToCamel(flag.stripPrefix("--")))
+    )
+    val context = TabCompletionContext(
+      options.format,
+      options.current,
+      head :: tail,
+      last,
+      secondLast,
+      setting,
+      inlined,
+      app
+    )
+    tabCompletions(subcommand, context).foreach { item =>
+      renderCompletion(item, app)
+    }
+  }
+  private def renderCompletions(items: List[String], app: CliApp): Unit = {
+    items.foreach { item =>
+      renderCompletion(TabCompletionItem(item), app)
+    }
+  }
+
+  private def renderCompletion(item: TabCompletionItem, app: CliApp): Unit = {
+    app.out.println(item.name)
+  }
+
+  private def tabCompletions(
+      command: Command[_],
+      context: TabCompletionContext
+  ): List[TabCompletionItem] = {
+    if (context.last.startsWith("-")) {
+      tabCompleteFlags(context)
+    } else {
+      if (context.setting.exists(_.isTabCompleteAsPath)) {
+        tabCompletePath(context)
+      } else {
+        context.setting.flatMap(_.tabCompleteOneOf) match {
+          case Some(oneof) =>
+            oneof.map(TabCompletionItem(_))
+          case None =>
+            val fromCommand = command.complete(context)
+            if (fromCommand.isEmpty && context.last == "") {
+              tabCompleteFlags(context)
+            } else {
+              fromCommand
+            }
+        }
+      }
+    }
+  }
+
+  private def tabCompleteFlags(
+      context: TabCompletionContext
+  ): List[TabCompletionItem] = {
+    context.allSettings
+      .filterNot {
+        case (_, setting) => setting.isPositionalArgument
+      }
+      .keys
+      .toList
+      .sorted
+      .map(camel => TabCompletionItem("--" + Case.camelToKebab(camel)))
+  }
+
+  private def tabCompletePath(
+      context: TabCompletionContext
+  ): List[TabCompletionItem] = {
+    val pathOrDirectory = Paths.get(context.last)
+    val absolutePathOrDirectory =
+      if (pathOrDirectory.isAbsolute()) pathOrDirectory
+      else context.app.workingDirectory.resolve(pathOrDirectory)
+    val path: Path =
+      if (context.last.endsWith(File.separator)) {
+        absolutePathOrDirectory
+      } else if (context.last.isEmpty()) {
+        absolutePathOrDirectory
+      } else {
+        Option(absolutePathOrDirectory.getParent())
+          .getOrElse(absolutePathOrDirectory)
+      }
+    if (Files.isDirectory(path)) {
+      path
+        .toFile()
+        .listFiles()
+        .iterator
+        .map(_.toPath())
+        .map { p =>
+          val slash = if (Files.isDirectory(p)) File.separator else ""
+          val prefix =
+            if (pathOrDirectory.isAbsolute()) {
+              p.toString()
+            } else {
+              context.app.workingDirectory.relativize(p).toString()
+            }
+          prefix + slash
+        }
+        .map(TabCompletionItem(_))
+        .toList
+        .sortBy(_.name)
+    } else {
+      Nil
+    }
+  }
+}

--- a/metaconfig-core/shared/src/main/scala/metaconfig/cli/TabCompleteOptions.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/cli/TabCompleteOptions.scala
@@ -1,0 +1,57 @@
+package metaconfig.cli
+
+import metaconfig._
+import metaconfig.annotation._
+import metaconfig.generic._
+import metaconfig.generic
+import metaconfig.internal.CliParser
+
+case class TabCompleteOptions(
+    current: Option[Int] = None,
+    format: Option[String] = None,
+    arguments: List[String] = Nil
+)
+object TabCompleteOptions {
+  val default = TabCompleteOptions()
+  implicit val surface: Surface[TabCompleteOptions] = new Surface(
+    List(
+      List(
+        new Field(
+          "current",
+          "Option[Int]",
+          List(),
+          Nil
+        ),
+        new Field(
+          "format",
+          "Option[String]",
+          List(),
+          Nil
+        ),
+        new Field(
+          "arguments",
+          "List[String]",
+          List(
+            new CatchInvalidFlags(),
+            new ExtraName(CliParser.PositionalArgument)
+          ),
+          Nil
+        )
+      )
+    )
+  )
+  implicit val encoder: ConfEncoder[TabCompleteOptions] =
+    ConfEncoder.StringEncoder
+      .contramap[TabCompleteOptions](_.arguments.mkString(" "))
+  implicit val decoder: ConfDecoder[TabCompleteOptions] = ConfDecoder.instance {
+    case obj: Conf.Obj =>
+      (obj.getOption[Int]("current") |@|
+        obj.getOption[String]("format") |@|
+        obj.get[List[String]]("remainingArgs"))
+        .map {
+          case ((a, b), c) => TabCompleteOptions(a, b, c)
+        }
+    case _ =>
+      Configured.ok(TabCompleteOptions())
+  }
+}

--- a/metaconfig-core/shared/src/main/scala/metaconfig/cli/TabCompletionContext.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/cli/TabCompletionContext.scala
@@ -1,0 +1,14 @@
+package metaconfig.cli
+
+import metaconfig.generic.Setting
+
+case class TabCompletionContext(
+    format: Option[String],
+    current: Option[Int],
+    arguments: List[String],
+    last: String,
+    secondLast: Option[String],
+    setting: Option[Setting],
+    allSettings: Map[String, Setting],
+    app: CliApp
+)

--- a/metaconfig-core/shared/src/main/scala/metaconfig/cli/TabCompletionItem.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/cli/TabCompletionItem.scala
@@ -1,0 +1,6 @@
+package metaconfig.cli
+
+case class TabCompletionItem(
+    name: String,
+    description: String = ""
+)

--- a/metaconfig-core/shared/src/main/scala/metaconfig/generic/Setting.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/generic/Setting.scala
@@ -2,6 +2,7 @@ package metaconfig.generic
 
 import scala.annotation.StaticAnnotation
 import metaconfig.annotation._
+import metaconfig.internal.CliParser
 
 final class Setting(val field: Field) {
   def name: String = field.name
@@ -45,6 +46,19 @@ final class Setting(val field: Field) {
     annotations.exists(_.isInstanceOf[Hidden])
   def isBoolean: Boolean =
     annotations.exists(_.isInstanceOf[Flag])
+  def isTabCompleteAsPath: Boolean =
+    annotations.exists(_.isInstanceOf[TabCompleteAsPath])
+  def isCatchInvalidFlags: Boolean =
+    annotations.exists(_.isInstanceOf[CatchInvalidFlags])
+  def isPositionalArgument: Boolean =
+    annotations.exists {
+      case ExampleValue(CliParser.PositionalArgument) => true
+      case _ => false
+    }
+  def tabCompleteOneOf: Option[List[String]] =
+    annotations.collectFirst {
+      case oneof: TabCompleteAsOneOf => oneof.options.toList
+    }
   @deprecated("Use isDynamic instead", "0.8.2")
   def isMap: Boolean = field.tpe.startsWith("Map")
   @deprecated("Use isDynamic instead", "0.8.2")

--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/Macros.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/Macros.scala
@@ -8,6 +8,8 @@ import metaconfig._
 import metaconfig.generic.Field
 import metaconfig.generic.Settings
 import metaconfig.generic.Surface
+import java.nio.file.Path
+import java.io.File
 
 object Macros
 class Macros(val c: blackbox.Context) {
@@ -160,7 +162,14 @@ class Macros(val c: blackbox.Context) {
             Nil
           }
 
-        val finalAnnots = repeated ::: dynamic ::: flag ::: baseAnnots
+        val tabCompletePath =
+          if (paramTpe <:< typeOf[Path] || paramTpe <:< typeOf[File]) {
+            q"new _root_.metaconfig.annotation.TabCompleteAsPath" :: Nil
+          } else {
+            Nil
+          }
+
+        val finalAnnots = repeated ::: dynamic ::: flag ::: tabCompletePath ::: baseAnnots
         val fieldsParamTpe = c.internal.typeRef(
           NoPrefix,
           weakTypeOf[Surface[_]].typeSymbol,

--- a/metaconfig-core/shared/src/test/scala/metaconfig/DeriveSurfaceSuite.scala
+++ b/metaconfig-core/shared/src/test/scala/metaconfig/DeriveSurfaceSuite.scala
@@ -10,9 +10,10 @@ class DeriveSurfaceSuite extends munit.FunSuite {
   test("toString") {
     val surface = generic.deriveSurface[WithFile]
     val obtained = surface.toString
-    val expected =
-      """Surface(List(List(Field(name="file",tpe="File",annotations=List(),underlying=List()))))"""
-    assertEquals(obtained, expected)
+    assertNoDiff(
+      obtained,
+      "Surface(List(List(Field(name=\"file\",tpe=\"File\",annotations=List(@TabCompleteAsPath()),underlying=List()))))"
+    )
   }
 
   case class Curried(a: Int)(b: List[Int])

--- a/metaconfig-tests/src/main/graal/reflection.json
+++ b/metaconfig-tests/src/main/graal/reflection.json
@@ -1,0 +1,11 @@
+[
+    {
+        "name": "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl",
+        "allDeclaredConstructors": true,
+        "allPublicConstructors": true,
+        "allDeclaredMethods": true,
+        "allPublicMethods": true,
+        "allDeclaredClasses": true,
+        "allPublicClasses": true
+    }
+]

--- a/metaconfig-tests/src/main/scala/metaconfig/tests/ExampleMain.scala
+++ b/metaconfig-tests/src/main/scala/metaconfig/tests/ExampleMain.scala
@@ -1,0 +1,48 @@
+package metaconfig.tests
+
+import metaconfig.cli.Command
+import java.nio.file.Path
+import java.nio.file.Paths
+import metaconfig.cli.CliApp
+import metaconfig.cli.HelpCommand
+import metaconfig.cli.VersionCommand
+import metaconfig.cli.TabCompleteCommand
+import metaconfig.annotation.ExtraName
+import metaconfig.annotation.TabCompleteAsPath
+
+case class ExampleOptions(
+    path: Path = Paths.get(".").toAbsolutePath().normalize(),
+    intellij: Boolean = false,
+    @ExtraName("remainingArgs")
+    arguments: List[String] = Nil
+)
+
+object ExampleOptions {
+  implicit val surface =
+    metaconfig.generic.deriveSurface[ExampleOptions]
+  implicit val codec =
+    metaconfig.generic.deriveCodec[ExampleOptions](ExampleOptions())
+}
+
+object ExampleCommand extends Command[ExampleOptions]("example") {
+  def run(value: Value, app: CliApp): Int = {
+    0
+  }
+}
+
+object ExampleMain {
+  val app = CliApp(
+    version = "1.0",
+    "hello",
+    List(
+      HelpCommand,
+      VersionCommand,
+      ExampleCommand,
+      TabCompleteCommand
+    )
+  )
+  def main(args: Array[String]): Unit = {
+    val exit = app.run(args.toList)
+    System.exit(exit)
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.5
+sbt.version=1.3.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.6.1")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.4.31")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.31")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")


### PR DESCRIPTION
Previously, metaconfig cli apps did not have any built-in support for
tab completions. However, metaconfig already has understanding of the
shape of the flags and subcommands so it's able to automatically provide
tab completions for most common use-cases.

Now, metaconfig cli apps can mix in the new `TabCompleteCommand`
that provides automatic completions. Custom subcommands can optionally
provide custom completions for unknown flags or positional arguments.

![2020-02-18 16 55 51](https://user-images.githubusercontent.com/1408093/74758692-930a6180-526f-11ea-8cf9-1808fd52f4b8.gif)

The GIF above demonstrates several features

* automatic --flag completions
* automatic subcommand comletions
* custom positional argument completion in "hello help SUBCOMMAND", that's implemented in `HelpCommand`. It's not so clear in the GIF, but the completions stop after selecting one subcommand.