### PR TITLE
PoC: append to default values

### DIFF
--- a/metaconfig-core/shared/src/main/scala/metaconfig/Conf.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/Conf.scala
@@ -28,9 +28,8 @@ sealed abstract class Conf extends Product with Serializable {
     ev.read(this)
   def getSettingOrElse[T](setting: Setting, default: T)(
       implicit ev: ConfDecoderWithDefaultMaybe[T]
-  ): Configured[T] = {
+  ): Configured[T] =
     ConfGet.getOrElse(this, default, setting.name, setting.alternativeNames: _*)
-  }
   def get[T](path: String, extraNames: String*)(
       implicit ev: ConfDecoder[T]
   ): Configured[T] =

--- a/metaconfig-core/shared/src/main/scala/metaconfig/Conf.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/Conf.scala
@@ -3,6 +3,7 @@ package metaconfig
 import java.io.File
 import scala.util.Try
 import metaconfig.Extractors._
+import metaconfig.ConfDecoder.ConfDecoderWithDefaultMaybe
 import metaconfig.generic.Setting
 import metaconfig.generic.Settings
 import metaconfig.internal.CliParser
@@ -26,16 +27,17 @@ sealed abstract class Conf extends Product with Serializable {
   def as[T](implicit ev: ConfDecoder[T]): Configured[T] =
     ev.read(this)
   def getSettingOrElse[T](setting: Setting, default: T)(
-      implicit ev: ConfDecoder[T]
-  ): Configured[T] =
+      implicit ev: ConfDecoderWithDefaultMaybe[T]
+  ): Configured[T] = {
     ConfGet.getOrElse(this, default, setting.name, setting.alternativeNames: _*)
+  }
   def get[T](path: String, extraNames: String*)(
       implicit ev: ConfDecoder[T]
   ): Configured[T] =
     ConfGet.get(this, path, extraNames: _*)
   def getOrElse[T](path: String, extraNames: String*)(
       default: T
-  )(implicit ev: ConfDecoder[T]): Configured[T] =
+  )(implicit ev: ConfDecoderWithDefaultMaybe[T]): Configured[T] =
     ConfGet.getOrElse(this, default, path, extraNames: _*)
 }
 

--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/ConfGet.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/ConfGet.scala
@@ -5,6 +5,7 @@ import metaconfig.Conf
 import metaconfig.ConfDecoder
 import metaconfig.ConfError
 import metaconfig.Configured
+import metaconfig.ConfDecoder.ConfDecoderWithDefaultMaybe
 
 object ConfGet {
   def getKey(obj: Conf, keys: Seq[String]): Option[Conf] =
@@ -20,10 +21,11 @@ object ConfGet {
     }
 
   def getOrElse[T](conf: Conf, default: T, path: String, extraNames: String*)(
-      implicit ev: ConfDecoder[T]
+      implicit ev: ConfDecoderWithDefaultMaybe[T]
   ): Configured[T] = {
     getKey(conf, path +: extraNames) match {
-      case Some(value) => ev.read(value)
+      case Some(value) =>
+        ev.fold(_.readWithDefault(value, default))(_.read(value))
       case None => Configured.Ok(default)
     }
   }

--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/Priority.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/Priority.scala
@@ -1,0 +1,55 @@
+package metaconfig.internal
+
+/**
+  * Copied from https://github.com/monix/implicitbox/blob/master/shared/src/main/scala/implicitbox/Priority.scala
+  * */
+private[metaconfig] sealed trait Priority[+P, +F] {
+  import Priority.{Fallback, Preferred}
+
+  def fold[B](f1: P => B)(f2: F => B): B =
+    this match {
+      case Preferred(x) => f1(x)
+      case Fallback(y) => f2(y)
+    }
+
+  def join[U >: P with F]: U =
+    fold(_.asInstanceOf[U])(_.asInstanceOf[U])
+
+  def bimap[P2, F2](f1: P => P2)(f2: F => F2): Priority[P2, F2] =
+    this match {
+      case Preferred(x) => Preferred(f1(x))
+      case Fallback(y) => Fallback(f2(y))
+    }
+
+  def toEither: Either[P, F] =
+    fold[Either[P, F]](p => Left(p))(f => Right(f))
+
+  def isPreferred: Boolean =
+    fold(_ => true)(_ => false)
+
+  def isFallback: Boolean =
+    fold(_ => false)(_ => true)
+
+  def getPreferred: Option[P] =
+    fold[Option[P]](p => Some(p))(_ => None)
+
+  def getFallback: Option[F] =
+    fold[Option[F]](_ => None)(f => Some(f))
+}
+
+private[metaconfig] object Priority extends FindPreferred {
+  final case class Preferred[P](get: P) extends Priority[P, Nothing]
+  final case class Fallback[F](get: F) extends Priority[Nothing, F]
+
+  def apply[P, F](implicit ev: Priority[P, F]): Priority[P, F] = ev
+}
+
+private[metaconfig] trait FindPreferred extends FindFallback {
+  implicit def preferred[P](implicit ev: P): Priority[P, Nothing] =
+    Priority.Preferred(ev)
+}
+
+private[metaconfig] trait FindFallback {
+  implicit def fallback[F](implicit ev: F): Priority[Nothing, F] =
+    Priority.Fallback(ev)
+}

--- a/metaconfig-core/shared/src/test/scala/metaconfig/ConfListTest.scala
+++ b/metaconfig-core/shared/src/test/scala/metaconfig/ConfListTest.scala
@@ -1,0 +1,73 @@
+package metaconfig
+
+import metaconfig.internal.CanBuildFromDecoder
+
+object ConfListTest {
+
+  case class Bar(add: List[String] = Nil)
+
+  implicit val barSurface: generic.Surface[Bar] =
+    generic.deriveSurface
+
+  implicit val barReader: ConfDecoder[Bar] =
+    generic.deriveDecoder[Bar](Bar()).noTypos
+
+  case class Foo(
+      field: List[String] = List("c"),
+      anotherField: List[String] = Nil,
+      bar: Bar = Bar()
+  )
+  implicit val surface: generic.Surface[Foo] =
+    generic.deriveSurface
+
+  implicit val reader: ConfDecoder[Foo] =
+    generic.deriveDecoder[Foo](Foo()).noTypos
+}
+
+class ConfListTest extends munit.FunSuite {
+  import ConfListTest.{Foo, Bar}
+  import Conf._
+
+  test("simple") {
+    val conf = Obj("field" -> Lst(Str("a"), Str("b")))
+    val obtained = conf.as[Foo].get
+    val expected = Foo(List("a", "b"))
+    assertEquals(obtained, expected)
+  }
+
+  test("missing") {
+    val conf = Obj()
+    val obtained = conf.as[Foo].get
+    val expected = Foo(List("c"), Nil)
+    assertEquals(obtained, expected)
+  }
+
+  test("add to default") {
+    val conf = Obj("field" -> Obj("add" -> Lst(Str("a"), Str("b"))))
+    val obtained = conf.as[Foo].get
+    val expected = Foo(List("c", "a", "b"))
+    assertEquals(obtained, expected)
+  }
+
+  test("don't touch another fields with same type") {
+    val conf = Obj(
+      "field" -> Obj("add" -> Lst(Str("a"), Str("b"))),
+      "anotherField" -> Lst(Str("d"))
+    )
+    val obtained = conf.as[Foo].get
+    val expected = Foo(List("c", "a", "b"), List("d"))
+    assertEquals(obtained, expected)
+  }
+
+  test("read config from foo.bar.add") {
+    val conf = Obj(
+      "field" -> Obj("add" -> Lst(Str("a"), Str("b"))),
+      "anotherField" -> Lst(Str("d")),
+      "bar" -> Obj("add" -> Lst(Str("e")))
+    )
+    val obtained = conf.as[Foo].get
+    val expected = Foo(List("c", "a", "b"), List("d"), Bar(List("e")))
+    assertEquals(obtained, expected)
+  }
+
+}

--- a/metaconfig-core/shared/src/test/scala/metaconfig/ConfMapTest.scala
+++ b/metaconfig-core/shared/src/test/scala/metaconfig/ConfMapTest.scala
@@ -1,0 +1,31 @@
+package metaconfig
+
+object ConfMapTest {
+  case class Foo(m: Map[String, Int] = Map("a" -> 1))
+
+  implicit val surface: generic.Surface[Foo] =
+    generic.deriveSurface
+
+  implicit val reader: ConfDecoder[Foo] =
+    generic.deriveDecoder[Foo](Foo()).noTypos
+
+}
+
+class ConfMapTest extends munit.FunSuite {
+  import ConfMapTest.Foo
+  import Conf._
+
+  test("simple") {
+    val conf = Obj("m" -> Obj("b" -> Num(2)))
+    val obtained = conf.as[Foo].get
+    val expected = Foo(Map("b" -> 2))
+    assertEquals(obtained, expected)
+  }
+
+  test("add defaults to map") {
+    val conf = Obj("m" -> Obj("add" -> Obj("b" -> Num(2))))
+    val obtained = conf.as[Foo].get
+    val expected = Foo(Map("a" -> 1, "b" -> 2))
+    assertEquals(obtained, expected)
+  }
+}

--- a/metaconfig-typesafe-config/src/test/scala/metaconfig/typesafeconfig/ReadHoconToCaseClass.scala
+++ b/metaconfig-typesafe-config/src/test/scala/metaconfig/typesafeconfig/ReadHoconToCaseClass.scala
@@ -1,0 +1,67 @@
+package metaconfig.typesafeconfig
+
+import metaconfig.generic
+import metaconfig.ConfDecoder
+import metaconfig.Conf
+import metaconfig.ConfCodec
+
+object ReadHoconToCaseClass {
+  case class Bar(lst: List[String] = List("a"))
+
+  implicit val barSurface: generic.Surface[Bar] =
+    generic.deriveSurface
+
+  implicit val barCodec: ConfCodec[Bar] =
+    generic.deriveCodec[Bar](Bar())
+
+  case class Foo(
+      x: String = "x",
+      y: Int = 2,
+      bar: Bar = Bar(),
+      xs: Map[String, Int] = Map("a" -> 1),
+      ys: List[Int] = List(1, 2)
+  )
+
+  implicit val surface: generic.Surface[Foo] =
+    generic.deriveSurface
+
+  implicit val codec: ConfCodec[Foo] =
+    generic.deriveCodec[Foo](Foo())
+}
+
+class ReadHoconToCaseClass extends munit.FunSuite {
+  import ReadHoconToCaseClass.{Foo, Bar}
+
+  test("read case class simple") {
+    val hocon = """
+    x = "hello"
+    bar.lst = ["b"]
+    xs = {
+      b = 4
+    }
+    ys = [3]
+    """
+
+    val parsed = Conf.parseString(hocon).get.as[Foo].get
+    val expected =
+      Foo("hello", 2, Bar(List("b")), Map("b" -> 4), List(3))
+    assertEquals(parsed, expected)
+  }
+
+  test("read case class from hocon with append") {
+    val hocon = """
+    x = "hello"
+    bar.lst.add = ["b"]
+    xs.add = {
+      b = 4
+    }
+    ys = [3]
+    """
+
+    val parsed = Conf.parseString(hocon).get.as[Foo].get
+    val expected =
+      Foo("hello", 2, Bar(List("a", "b")), Map("a" -> 1, "b" -> 4), List(3))
+    assertEquals(parsed, expected)
+  }
+
+}


### PR DESCRIPTION
## Problem

Scalafmt has several lists with default values in config. If users want to add new value to it, they need to copy all defaults into their `.scalafmt.conf`. Also scalafmt has ad-hoc solution for one of such lists: [align.tokens.add](https://scalameta.org/scalafmt/docs/configuration.html#aligntokensadd).

I believe that ability to extend _any_ default list would significantly improve UX of configuring. 

There are two solutions:
* add ad-hocs like for `align.tokens` to all scalafmt parameters
* support this feature on the configuration library side

## Concept

Introduced `ConfDecoderWithDefault` typeclass inherited from `ConfDecoder`. Add its instances to `Map[String, T]` and iterable collections. Such instances check `.add` prefix in the HOCON keys and append values to default (fetched from case class). In `ConfGet` on implicit resolution stage compiler check it there instance of `ConfDecoderWithDefault` for that type. If yes - read with default value. If no - reads the old way.

_I am open to any suggestions about design, API and other things. And I understand that these changes may not be accepted. But if it's OK, I will document new abilities._

## Result

Define config as case classes with default values with usual codecs:
```scala
case class Bar(lst: List[String] = List("a"))

case class Foo(
    x: String = "x",
    y: Int = 2,
    bar: Bar = Bar(),
    xs: Map[String, Int] = Map("a" -> 1),
    ys: List[Int] = List(1, 2)
)

...

implicit val codec: ConfCodec[Foo] =
    generic.deriveCodec[Foo](Foo())
```

Use `.add` syntax in HOCON:
```
x = "hello"
bar.lst.add = ["b"]
xs.add = {
   b = 4
}
ys = [3]
```
Get the result:
```scala
Foo("hello", 2, Bar(List("a", "b")), Map("a" -> 1, "b" -> 4), List(3))
```
## Disadvantages of this implementation

1. Library code sophistication
2. If you write
```scala
implicitly[ConfDecoder[List[String]].map(x => ...)
```
on the user side, you miss defaults magic. User always need to write
```scala
implicitly[ConfDecoderWithDefault[List[String]].mapWithDefault(x => ...)(d => ...)
```
3. `CanBuildFromDecoder` now requires `C[X] <: Iterable[X]` on collection type because there is no possibility to concat `C[A]` and `C[A]` with `Factory` only
4. I don't like this solution, it looks overcomplicated. But I couldn't think of anything better :disappointed: 

Related: https://github.com/scalameta/scalafmt/issues/1490