### PR TITLE
Automatically support `--no` prefix for boolean flags.

### DIFF
--- a/metaconfig-core/jvm/src/test/scala/metaconfig/cli/BaseCliParserSuite.scala
+++ b/metaconfig-core/jvm/src/test/scala/metaconfig/cli/BaseCliParserSuite.scala
@@ -1,0 +1,50 @@
+package metaconfig.cli
+
+import java.nio.file.Paths
+import metaconfig.annotation._
+import metaconfig._
+import metaconfig.generic.Settings
+import java.io.File
+
+class BaseCliParserSuite extends munit.FunSuite {
+  val settings = Settings[Options]
+  def toString(options: Options): String = {
+    settings.settings
+      .zip(options.productIterator.toList)
+      .map {
+        case (s, v) =>
+          s"${s.name} = $v"
+      }
+      .mkString("\n")
+  }
+  def check(
+      name: String,
+      args: List[String],
+      expectedOptions: Options
+  )(implicit loc: munit.Location): Unit = {
+    test(name) {
+      val conf = Conf.parseCliArgs[Options](args).get
+      val obtainedOptions = ConfDecoder[Options].read(conf).get
+      val obtained = toString(obtainedOptions)
+      val expected = toString(expectedOptions)
+      assertNoDiff(obtained, expected)
+    }
+  }
+
+  def checkError(
+      name: String,
+      args: List[String],
+      expected: String
+  ): Unit = {
+    test(name) {
+      val options = Conf
+        .parseCliArgs[Options](args)
+        .andThen(_.as[Options])
+      val obtained = options match {
+        case Configured.Ok(value) => value.toString()
+        case Configured.NotOk(error) => error.all.mkString("\n")
+      }
+      assertNoDiff(obtained, expected)
+    }
+  }
+}

--- a/metaconfig-core/jvm/src/test/scala/metaconfig/cli/CliSuite.scala
+++ b/metaconfig-core/jvm/src/test/scala/metaconfig/cli/CliSuite.scala
@@ -69,6 +69,12 @@ class CliSuite extends munit.FunSuite {
        |--google-analytics List[String] (default: [])
        |--classpath List[String] (default: [])
        |--clean-target
+       |--default-true
+       |--default-false
+       |--no-flip-default-true
+       |--no-flip-default-false
+       |--conflict
+       |--no-conflict
        |--base-url String (default: "")
        |--encoding String (default: "UTF-8")
        |

--- a/metaconfig-core/jvm/src/test/scala/metaconfig/cli/Options.scala
+++ b/metaconfig-core/jvm/src/test/scala/metaconfig/cli/Options.scala
@@ -1,0 +1,47 @@
+package metaconfig.cli
+
+import java.nio.file.Paths
+import metaconfig.annotation._
+import metaconfig._
+import metaconfig.generic.Settings
+import java.io.File
+
+case class Options(
+    @Description("The input directory to generate the fox site.")
+    @ExtraName("i")
+    in: String = Paths.get("docs").toString,
+    @Description("The output directory to generate the fox site.")
+    @ExtraName("o")
+    out: String = Paths.get("target").resolve("fox").toString,
+    cwd: String = Paths.get(".").toAbsolutePath.toString,
+    repoName: String = "olafurpg/fox",
+    repoUrl: String = "https://github.com/olafurpg/fox",
+    title: String = "Fox",
+    description: String = "My Description",
+    googleAnalytics: List[String] = Nil,
+    classpath: List[String] = Nil,
+    cleanTarget: Boolean = false,
+    defaultTrue: Boolean = true,
+    defaultFalse: Boolean = false,
+    noFlipDefaultTrue: Boolean = true,
+    noFlipDefaultFalse: Boolean = false,
+    conflict: Boolean = false,
+    noConflict: Boolean = false,
+    @Description("")
+    baseUrl: String = "",
+    encoding: String = "UTF-8",
+    @Section("Advanced")
+    configPath: String = Paths.get("fox.conf").toString,
+    remainingArgs: List[String] = Nil,
+    conf: Conf = Conf.Obj(),
+    site: Site = Site(),
+    @Inline
+    inlined: Site = Site(),
+    @Hidden // should not appear in --help
+    hidden: Int = 87
+)
+object Options {
+  implicit val surface = generic.deriveSurface[Options]
+  implicit val codec: ConfCodec[Options] =
+    generic.deriveCodec[Options](Options())
+}

--- a/metaconfig-core/jvm/src/test/scala/metaconfig/cli/Site.scala
+++ b/metaconfig-core/jvm/src/test/scala/metaconfig/cli/Site.scala
@@ -1,0 +1,16 @@
+package metaconfig.cli
+
+import java.nio.file.Paths
+import metaconfig.annotation._
+import metaconfig._
+import metaconfig.generic.Settings
+import java.io.File
+
+case class Site(
+    foo: String = "foo",
+    custom: Map[String, String] = Map.empty
+)
+object Site {
+  implicit val surface = generic.deriveSurface[Site]
+  implicit val codec = generic.deriveCodec[Site](Site())
+}

--- a/metaconfig-core/shared/src/main/scala/metaconfig/Configured.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/Configured.scala
@@ -13,6 +13,11 @@ sealed abstract class Configured[+A] extends Product with Serializable {
     case Ok(value) => value
     case NotOk(error) => throw new NoSuchElementException(error.toString)
   }
+  def orElse[B >: A](alternative: => Configured[B]): Configured[B] =
+    this match {
+      case _: NotOk => alternative
+      case ok => ok
+    }
   def toEither: Either[ConfError, A] = this match {
     case Ok(value) => Right(value)
     case NotOk(error) => Left(error)

--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/CliParser.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/CliParser.scala
@@ -5,7 +5,134 @@ import metaconfig.generic.Setting
 import metaconfig.generic.Settings
 import metaconfig.Configured.ok
 import metaconfig.annotation.Inline
-import scala.collection.immutable.Nil
+import metaconfig.Configured.Ok
+import metaconfig.Configured.NotOk
+
+class CliParser[T](
+    args: List[String],
+    settings: Settings[T],
+    toInline: Map[String, Setting]
+) {
+  import CliParser._
+  def loop(
+      curr: Conf.Obj,
+      xs: List[String],
+      s: State
+  ): Configured[Conf.Obj] = {
+    (xs, s) match {
+      case (Nil, NoFlag) => ok(curr)
+      case (Nil, Flag(flag, setting)) =>
+        if (setting.isBoolean) ok(add(curr, flag, Conf.fromBoolean(true)))
+        else {
+          ConfError
+            .message(
+              s"the argument '--${Case.camelToKebab(flag)}' requires a value but none was supplied"
+            )
+            .notOk
+        }
+      case (head :: tail, NoFlag) =>
+        val equal = head.indexOf('=')
+        if (equal >= 0) { // split "--key=value" into ["--key", "value"]
+          val key = head.substring(0, equal)
+          val value = head.substring(equal + 1)
+          loop(curr, key :: value :: tail, NoFlag)
+        } else if (head.startsWith("-")) {
+          tryFlag(curr, head, tail, s, defaultBooleanValue = true) match {
+            case nok: NotOk if head.startsWith("--") =>
+              val fallbackFlag =
+                if (head.startsWith(noPrefix)) {
+                  "--" + head.stripPrefix(noPrefix)
+                } else {
+                  noPrefix + head.stripPrefix("--")
+                }
+              val fallback =
+                tryFlag(
+                  curr,
+                  fallbackFlag,
+                  tail,
+                  s,
+                  defaultBooleanValue = false
+                )
+              fallback.orElse(nok)
+            case ok => ok
+          }
+        } else {
+          val positionalArgs =
+            appendValues(
+              curr,
+              PositionalArgument,
+              List(Conf.fromString(head))
+            )
+          loop(add(curr, PositionalArgument, positionalArgs), tail, NoFlag)
+        }
+      case (head :: tail, Flag(flag, setting)) =>
+        val value = Conf.fromString(head)
+        val newCurr =
+          if (setting.isRepeated) {
+            appendValues(curr, flag, List(value))
+          } else {
+            value
+          }
+        loop(add(curr, flag, newCurr), tail, NoFlag)
+    }
+  }
+
+  private def tryFlag(
+      curr: Conf.Obj,
+      head: String,
+      tail: List[String],
+      s: State,
+      defaultBooleanValue: Boolean
+  ): Configured[Conf.Obj] = {
+    val camel = Case.kebabToCamel(dash.replaceFirstIn(head, ""))
+    camel.split("\\.").toList match {
+      case Nil =>
+        ConfError.message(s"Flag '$head' must not be empty").notOk
+      case flag :: flags =>
+        val (key, keys) = toInline.get(flag) match {
+          case Some(setting) => setting.name -> (flag :: flags)
+          case _ => flag -> flags
+        }
+        settings.get(key, keys) match {
+          case None =>
+            settings.settings.find(_.isCatchInvalidFlags) match {
+              case None =>
+                val closestCandidate =
+                  Levenshtein.closestCandidate(camel, settings.names)
+                val didYouMean = closestCandidate match {
+                  case None =>
+                    ""
+                  case Some(candidate) =>
+                    val kebab = Case.camelToKebab(candidate)
+                    s"\n\tDid you mean '--$kebab'?"
+                }
+                ConfError
+                  .message(
+                    s"found argument '--$flag' which wasn't expected, or isn't valid in this context.$didYouMean"
+                  )
+                  .notOk
+              case Some(fallback) =>
+                val values = appendValues(
+                  curr,
+                  PositionalArgument,
+                  (head :: tail).map(Conf.fromString)
+                )
+                ok(add(curr, PositionalArgument, values))
+            }
+          case Some(setting) =>
+            val prefix = toInline.get(flag).fold("")(_.name + ".")
+            val toAdd = prefix + camel
+            if (setting.isBoolean) {
+              val newCurr =
+                add(curr, toAdd, Conf.fromBoolean(defaultBooleanValue))
+              loop(newCurr, tail, NoFlag)
+            } else {
+              loop(curr, tail, Flag(toAdd, setting))
+            }
+        }
+    }
+  }
+}
 
 object CliParser {
   val PositionalArgument = "remainingArgs"
@@ -14,104 +141,19 @@ object CliParser {
       args: List[String]
   )(implicit settings: Settings[T]): Configured[Conf] = {
     val toInline = inlinedSettings(settings)
-    def loop(
-        curr: Conf.Obj,
-        xs: List[String],
-        s: State
-    ): Configured[Conf.Obj] = {
-      def add(key: String, value: Conf): Conf.Obj = {
-        val values = curr.values.filterNot {
-          case (k, _) => k == key
-        }
-        Conf.Obj((key, value) :: values)
-      }
-
-      (xs, s) match {
-        case (Nil, NoFlag) => ok(curr)
-        case (Nil, Flag(flag, setting)) =>
-          if (setting.isBoolean) ok(add(flag, Conf.fromBoolean(true)))
-          else {
-            ConfError
-              .message(
-                s"the argument '--${Case.camelToKebab(flag)}' requires a value but none was supplied"
-              )
-              .notOk
-          }
-        case (head :: tail, NoFlag) =>
-          val equal = head.indexOf('=')
-          if (equal >= 0) { // split "--key=value" into ["--key", "value"]
-            val key = head.substring(0, equal)
-            val value = head.substring(equal + 1)
-            loop(curr, key :: value :: tail, NoFlag)
-          } else if (head.startsWith("-")) {
-            val camel = Case.kebabToCamel(dash.replaceFirstIn(head, ""))
-            camel.split("\\.").toList match {
-              case Nil =>
-                ConfError.message(s"Flag '$head' must not be empty").notOk
-              case flag :: flags =>
-                val (key, keys) = toInline.get(flag) match {
-                  case Some(setting) => setting.name -> (flag :: flags)
-                  case _ => flag -> flags
-                }
-                settings.get(key, keys) match {
-                  case None =>
-                    settings.settings.find(_.isCatchInvalidFlags) match {
-                      case None =>
-                        val closestCandidate =
-                          Levenshtein.closestCandidate(camel, settings.names)
-                        val didYouMean = closestCandidate match {
-                          case None =>
-                            ""
-                          case Some(candidate) =>
-                            val kebab = Case.camelToKebab(candidate)
-                            s"\n\tDid you mean '--$kebab'?"
-                        }
-                        ConfError
-                          .message(
-                            s"found argument '--$flag' which wasn't expected, or isn't valid in this context.$didYouMean"
-                          )
-                          .notOk
-                      case Some(fallback) =>
-                        val values = appendValues(
-                          curr,
-                          PositionalArgument,
-                          xs.map(Conf.fromString)
-                        )
-                        ok(add(PositionalArgument, values))
-                    }
-                  case Some(setting) =>
-                    val prefix = toInline.get(flag).fold("")(_.name + ".")
-                    val toAdd = prefix + camel
-                    if (setting.isBoolean) {
-                      val newCurr = add(toAdd, Conf.fromBoolean(true))
-                      loop(newCurr, tail, NoFlag)
-                    } else {
-                      loop(curr, tail, Flag(toAdd, setting))
-                    }
-                }
-            }
-          } else {
-            val positionalArgs =
-              appendValues(
-                curr,
-                PositionalArgument,
-                List(Conf.fromString(head))
-              )
-            loop(add(PositionalArgument, positionalArgs), tail, NoFlag)
-          }
-        case (head :: tail, Flag(flag, setting)) =>
-          val value = Conf.fromString(head)
-          val newCurr =
-            if (setting.isRepeated) {
-              appendValues(curr, flag, List(value))
-            } else {
-              value
-            }
-          loop(add(flag, newCurr), tail, NoFlag)
-      }
-    }
-    loop(Conf.Obj(), args, NoFlag).map(_.normalize)
+    val parser = new CliParser[T](args, settings, toInline)
+    parser.loop(Conf.Obj(), args, NoFlag).map(_.normalize)
   }
+
+  private def add(curr: Conf.Obj, key: String, value: Conf): Conf.Obj = {
+    val values = curr.values.filterNot {
+      case (k, _) => k == key
+    }
+    Conf.Obj((key, value) :: values)
+  }
+
+  val noPrefix = "--no-"
+  def isNegatedBoolean(flag: String): Boolean = flag.startsWith(noPrefix)
 
   def appendValues(obj: Conf.Obj, key: String, values: List[Conf]): Conf.Lst = {
     obj.map.get(key) match {


### PR DESCRIPTION
Previously, if you had boolean flag like `sources: Boolean` with default
value true then there was no way for cli users to set the value to
false because `--sources` can only set the boolean to true. Now, users
can pass the flag `--no-sources` to make the boolean value false.

This diff ended up being trickier to implement than I expected because
we need to make sure that it's still OK to name fields with a `--no-`
prefix, such as `noSources: Boolean`. This feature is implemented in a
fully backwards compatible way by always trying first to use the default
parsing logic and only falling back to guessing the addition or removal
of the `--no-` prefix. This means that a boolean flag named `noSources:
Boolean` can also be overriden with the `--sources` flag.